### PR TITLE
Correción en WorkFlow

### DIFF
--- a/.github/workflows/NuGet.yml
+++ b/.github/workflows/NuGet.yml
@@ -48,7 +48,7 @@ jobs:
           $tagRaw = '${{ github.ref }}'
           $tag = if ($tagRaw -match 'refs/tags/(?:v|release-)?([\d\.]+)') { $matches[1] } else { $tagRaw -replace 'refs/tags/', '' }
           $projects = Get-ChildItem -Path . -Recurse -Include *.csproj | Where-Object {
-            $_.FullName -notmatch 'Test|Tests|\.Tests\'} # Excluye proyectos de pruebas
+                      $_.FullName -notmatch 'Test|Tests|\.Tests'} # Excluye proyectos de pruebas
           
           foreach ($proj in $projects) {
             $isNet48 = Select-String -Path $proj.FullName -Pattern '<TargetFramework.*>net48' -Quiet


### PR DESCRIPTION
Corrige filtro de proyectos de prueba en NuGet.yml

Se ha eliminado un guion adicional en la línea que excluye proyectos que contienen 'Test', 'Tests' o '.Tests'. Esto asegura que la lógica de exclusión funcione correctamente.