### PR TITLE
Documentación XML y comentarios para KUtilitiesCore.Extensions

### DIFF
--- a/KUtilitiesCore/Extensions/DataAnnotationsExt.cs
+++ b/KUtilitiesCore/Extensions/DataAnnotationsExt.cs
@@ -15,31 +15,49 @@ namespace KUtilitiesCore.Extensions
     {
         #region Methods
         /// <summary>
-        /// Proporciona el texto de la propiedad que corresponde a la Descripción que se mostrará al usuario
+        /// Proporciona el texto de la propiedad que corresponde a la Descripción que se mostrará al usuario.
         /// </summary>
+        /// <remarks>
+        /// Este método y sus sobrecargas permiten obtener la descripción de una propiedad de diversas maneras:
+        /// - Especificando el tipo fuente y el nombre de la propiedad.
+        /// - Usando una instancia del objeto y el nombre de la propiedad.
+        /// - Directamente desde un objeto <see cref="PropertyInfo"/>.
+        /// - Mediante una expresión lambda que accede a la propiedad.
+        /// La descripción se obtiene prioritariamente del atributo <see cref="DisplayAttribute.Description"/>,
+        /// y si no está presente, del atributo <see cref="DescriptionAttribute"/>.
+        /// </remarks>
+        /// <typeparam name="TSource">El tipo de la clase que contiene la propiedad.</typeparam>
+        /// <param name="propertyName">El nombre de la propiedad.</param>
+        /// <returns>La descripción de la propiedad; o una cadena vacía si no se encuentra.</returns>
         public static string DataAnnotationsDescription<TSource>(string propertyName)
         {
             return typeof(TSource).DataAnnotationsDescription(propertyName);
         }
 
         /// <summary>
-        /// Proporciona el texto de la propiedad que corresponde a la Descripción que se mostrará al usuario
+        /// Proporciona el texto de la propiedad que corresponde a la Descripción que se mostrará al usuario.
         /// </summary>
-        /// <param name="Source"></param>
-        /// <param name="propertyName">Nombre de la propiedad que se desea buscar</param>
-        /// <returns></returns>
+        /// <param name="Source">El tipo de la clase que contiene la propiedad.</param>
+        /// <param name="propertyName">Nombre de la propiedad que se desea buscar.</param>
+        /// <returns>La descripción de la propiedad; o una cadena vacía si no se encuentra.</returns>
         public static string DataAnnotationsDescription(this Type Source, string propertyName)
             => DataAnnotationsHelpers.GetDescriptionCore(Source, propertyName);
 
         /// <summary>
-        /// Proporciona el texto de la propiedad que corresponde a la Descripción que se mostrará al usuario
+        /// Proporciona el texto de la propiedad que corresponde a la Descripción que se mostrará al usuario.
         /// </summary>
+        /// <typeparam name="TSource">El tipo del objeto que contiene la propiedad.</typeparam>
+        /// <param name="source">La instancia del objeto.</param>
+        /// <param name="propertyName">Nombre de la propiedad que se desea buscar.</param>
+        /// <returns>La descripción de la propiedad; o una cadena vacía si no se encuentra.</returns>
         public static string DataAnnotationsDescription<TSource>(this TSource source, string propertyName)
         => DataAnnotationsHelpers.GetDescriptionCore(source?.GetType() ?? typeof(TSource), propertyName);
 
         /// <summary>
-        /// Proporciona el texto de la propiedad que corresponde a la Descripción que se mostrará al usuario
+        /// Proporciona el texto de la propiedad que corresponde a la Descripción que se mostrará al usuario.
         /// </summary>
+        /// <param name="pi">El objeto <see cref="PropertyInfo"/> que representa la propiedad.</param>
+        /// <returns>La descripción de la propiedad; o una cadena vacía si no se encuentra.</returns>
         public static string DataAnnotationsDescription(this PropertyInfo pi)
         {
             DisplayAttribute? ret = DataAnnotationsHelpers.GetAttribCore<DisplayAttribute>(pi);
@@ -52,8 +70,12 @@ namespace KUtilitiesCore.Extensions
         }
 
         /// <summary>
-        /// Proporciona el texto de la propiedad que corresponde a la Descripción que se mostrará al usuario
+        /// Proporciona el texto de la propiedad que corresponde a la Descripción que se mostrará al usuario.
         /// </summary>
+        /// <typeparam name="TSource">El tipo de la clase que contiene la propiedad.</typeparam>
+        /// <typeparam name="TProperty">El tipo de la propiedad.</typeparam>
+        /// <param name="propertyAccesor">Una expresión lambda que accede a la propiedad (ej. `x => x.PropertyName`).</param>
+        /// <returns>La descripción de la propiedad; o una cadena vacía si no se encuentra.</returns>
         public static string DataAnnotationsDescription<TSource, TProperty>(this Expression<Func<TSource, TProperty>> propertyAccesor)
         {
             MemberInfo mi = ExpressionsHelpers.GetPropertyInformation(propertyAccesor.Body);
@@ -61,20 +83,38 @@ namespace KUtilitiesCore.Extensions
         }
 
         /// <summary>
-        /// Proporciona el texto de presentación de una propiedad.
+        /// Proporciona el texto de presentación de una propiedad, usualmente una cadena de formato.
         /// </summary>
+        /// <remarks>
+        /// Este método y sus sobrecargas permiten obtener la cadena de formato de una propiedad de diversas maneras:
+        /// - Especificando el tipo fuente y el nombre de la propiedad.
+        /// - Usando una instancia del objeto y el nombre de la propiedad.
+        /// - Directamente desde un objeto <see cref="PropertyInfo"/>.
+        /// - Mediante una expresión lambda que accede a la propiedad.
+        /// La cadena de formato se obtiene del atributo <see cref="DisplayFormatAttribute.DataFormatString"/>.
+        /// Si no se encuentra, se devuelve el nombre de la propiedad.
+        /// </remarks>
+        /// <param name="Source">El tipo de la clase que contiene la propiedad.</param>
+        /// <param name="propertyName">El nombre de la propiedad.</param>
+        /// <returns>La cadena de formato de la propiedad; o el nombre de la propiedad si no se encuentra un formato.</returns>
         public static string DataAnnotationsDisplayFormat(this Type Source, string propertyName)
              => DataAnnotationsHelpers.GetDisplayFormatCore(Source, propertyName);
 
         /// <summary>
-        /// Proporciona el texto de presentación de una propiedad.
+        /// Proporciona el texto de presentación de una propiedad, usualmente una cadena de formato.
         /// </summary>
+        /// <typeparam name="TSource">El tipo del objeto que contiene la propiedad.</typeparam>
+        /// <param name="source">La instancia del objeto.</param>
+        /// <param name="propertyName">El nombre de la propiedad.</param>
+        /// <returns>La cadena de formato de la propiedad; o el nombre de la propiedad si no se encuentra un formato.</returns>
         public static string DataAnnotationsDisplayFormat<TSource>(this TSource source, string propertyName)
             => DataAnnotationsHelpers.GetDisplayFormatCore(source?.GetType() ?? typeof(TSource), propertyName);
 
         /// <summary>
-        /// Proporciona el texto de presentación de una propiedad.
+        /// Proporciona el texto de presentación de una propiedad, usualmente una cadena de formato.
         /// </summary>
+        /// <param name="pi">El objeto <see cref="PropertyInfo"/> que representa la propiedad.</param>
+        /// <returns>La cadena de formato de la propiedad; o el nombre de la propiedad si no se encuentra un formato.</returns>
         public static string DataAnnotationsDisplayFormat(this PropertyInfo pi)
         {
             DisplayFormatAttribute? ret = DataAnnotationsHelpers.GetAttribCore<DisplayFormatAttribute>(pi);
@@ -82,8 +122,12 @@ namespace KUtilitiesCore.Extensions
         }
 
         /// <summary>
-        /// Proporciona el texto de presentación de una propiedad.
+        /// Proporciona el texto de presentación de una propiedad, usualmente una cadena de formato.
         /// </summary>
+        /// <typeparam name="TSource">El tipo de la clase que contiene la propiedad.</typeparam>
+        /// <typeparam name="TProperty">El tipo de la propiedad.</typeparam>
+        /// <param name="propertyAccesor">Una expresión lambda que accede a la propiedad (ej. `x => x.PropertyName`).</param>
+        /// <returns>La cadena de formato de la propiedad; o el nombre de la propiedad si no se encuentra un formato.</returns>
         public static string DataAnnotationsDisplayFormat<TSource, TProperty>(this Expression<Func<TSource, TProperty>> propertyAccesor)
         {
             MemberInfo mi = ExpressionsHelpers.GetPropertyInformation(propertyAccesor.Body);
@@ -91,22 +135,40 @@ namespace KUtilitiesCore.Extensions
         }
 
         /// <summary>
-        /// Proporciona el texto para mostrar de un propiedad.
+        /// Proporciona el texto para mostrar de una propiedad, comúnmente usado para etiquetas en la UI.
         /// </summary>
+        /// <remarks>
+        /// Este método y sus sobrecargas permiten obtener el nombre para mostrar (Display Name) de una propiedad de varias maneras:
+        /// - Usando una instancia del objeto y el nombre de la propiedad.
+        /// - Especificando el tipo fuente y el nombre de la propiedad.
+        /// - Directamente desde un objeto <see cref="PropertyInfo"/>.
+        /// - Mediante una expresión lambda que accede a la propiedad.
+        /// El nombre para mostrar se obtiene prioritariamente del atributo <see cref="DisplayAttribute.Name"/>,
+        /// y si no está presente, del atributo <see cref="DisplayNameAttribute"/>. Si ninguno está presente,
+        /// se devuelve el nombre de la propiedad.
+        /// </remarks>
+        /// <typeparam name="TSource">El tipo del objeto que contiene la propiedad.</typeparam>
+        /// <param name="source">La instancia del objeto.</param>
+        /// <param name="propertyName">El nombre de la propiedad.</param>
+        /// <returns>El nombre para mostrar de la propiedad; o el nombre de la propiedad si no se encuentra uno específico.</returns>
         public static string DataAnnotationsDisplayName<TSource>(this TSource source, string propertyName)
             => DataAnnotationsHelpers.GetDisplayNameCore(source?.GetType() ?? typeof(TSource), propertyName);
 
         /// <summary>
-        /// Proporciona el texto para mostrar de un propiedad.
+        /// Proporciona el texto para mostrar de una propiedad.
         /// </summary>
-        /// <returns>Regresa el valor que contiene el atributo en DataAnnotations,
-        /// de lo contrario el nombre de la propiedad</returns>
+        /// <param name="SourceType">El tipo de la clase que contiene la propiedad.</param>
+        /// <param name="propertyName">El nombre de la propiedad.</param>
+        /// <returns>Regresa el valor que contiene el atributo en DataAnnotations;
+        /// de lo contrario, el nombre de la propiedad.</returns>
         public static string DataAnnotationsDisplayName(this Type SourceType, string propertyName)
             => DataAnnotationsHelpers.GetDisplayNameCore(SourceType, propertyName);
 
         /// <summary>
-        /// Proporciona el texto para mostrar de un propiedad.
+        /// Proporciona el texto para mostrar de una propiedad.
         /// </summary>
+        /// <param name="pi">El objeto <see cref="PropertyInfo"/> que representa la propiedad.</param>
+        /// <returns>El nombre para mostrar de la propiedad; o el nombre de la propiedad si no se encuentra uno específico.</returns>
         public static string DataAnnotationsDisplayName(this PropertyInfo pi)
         {
             DisplayAttribute? ret = DataAnnotationsHelpers.GetAttribCore<DisplayAttribute>(pi);
@@ -119,8 +181,12 @@ namespace KUtilitiesCore.Extensions
         }
 
         /// <summary>
-        /// Proporciona el texto para mostrar de un propiedad.
+        /// Proporciona el texto para mostrar de una propiedad.
         /// </summary>
+        /// <typeparam name="TSource">El tipo de la clase que contiene la propiedad.</typeparam>
+        /// <typeparam name="TProperty">El tipo de la propiedad.</typeparam>
+        /// <param name="propertyAccesor">Una expresión lambda que accede a la propiedad (ej. `x => x.PropertyName`).</param>
+        /// <returns>El nombre para mostrar de la propiedad; o el nombre de la propiedad si no se encuentra uno específico.</returns>
         public static string DataAnnotationsDisplayName<TSource, TProperty>(this Expression<Func<TSource, TProperty>> propertyAccesor)
         {
             MemberInfo mi = ExpressionsHelpers.GetPropertyInformation(propertyAccesor.Body);
@@ -128,20 +194,38 @@ namespace KUtilitiesCore.Extensions
         }
 
         /// <summary>
-        /// Proporciona el texto para mostrar de un propiedad.
+        /// Proporciona el nombre corto para mostrar de una propiedad.
         /// </summary>
+        /// <remarks>
+        /// Este método y sus sobrecargas permiten obtener el nombre corto para mostrar (Short Name) de una propiedad de varias maneras:
+        /// - Especificando el tipo fuente y el nombre de la propiedad.
+        /// - Usando una instancia del objeto y el nombre de la propiedad.
+        /// - Directamente desde un objeto <see cref="PropertyInfo"/>.
+        /// - Mediante una expresión lambda que accede a la propiedad.
+        /// El nombre corto se obtiene del atributo <see cref="DisplayAttribute.ShortName"/>. Si no está presente,
+        /// se devuelve el nombre de la propiedad.
+        /// </remarks>
+        /// <param name="Source">El tipo de la clase que contiene la propiedad.</param>
+        /// <param name="propertyName">El nombre de la propiedad.</param>
+        /// <returns>El nombre corto para mostrar de la propiedad; o el nombre de la propiedad si no se encuentra uno específico.</returns>
         public static string DataAnnotationsDisplayShortName(this Type Source, string propertyName)
             => DataAnnotationsHelpers.GetShortNameCore(Source, propertyName);
 
         /// <summary>
-        /// Proporciona el texto para mostrar de un propiedad.
+        /// Proporciona el nombre corto para mostrar de una propiedad.
         /// </summary>
+        /// <typeparam name="TSource">El tipo del objeto que contiene la propiedad.</typeparam>
+        /// <param name="source">La instancia del objeto.</param>
+        /// <param name="propertyName">El nombre de la propiedad.</param>
+        /// <returns>El nombre corto para mostrar de la propiedad; o el nombre de la propiedad si no se encuentra uno específico.</returns>
         public static string DataAnnotationsDisplayShortName<TSource>(this TSource source, string propertyName)
             => DataAnnotationsHelpers.GetShortNameCore(source?.GetType() ?? typeof(TSource), propertyName);
 
         /// <summary>
-        /// Proporciona el texto para mostrar de un propiedad.
+        /// Proporciona el nombre corto para mostrar de una propiedad.
         /// </summary>
+        /// <param name="pi">El objeto <see cref="PropertyInfo"/> que representa la propiedad.</param>
+        /// <returns>El nombre corto para mostrar de la propiedad; o el nombre de la propiedad si no se encuentra uno específico.</returns>
         public static string DataAnnotationsDisplayShortName(this PropertyInfo pi)
         {
             DisplayAttribute? ret = DataAnnotationsHelpers.GetAttribCore<DisplayAttribute>(pi);
@@ -149,8 +233,12 @@ namespace KUtilitiesCore.Extensions
         }
 
         /// <summary>
-        /// Proporciona el texto para mostrar de un propiedad.
+        /// Proporciona el nombre corto para mostrar de una propiedad.
         /// </summary>
+        /// <typeparam name="TSource">El tipo de la clase que contiene la propiedad.</typeparam>
+        /// <typeparam name="TProperty">El tipo de la propiedad.</typeparam>
+        /// <param name="propertyAccesor">Una expresión lambda que accede a la propiedad (ej. `x => x.PropertyName`).</param>
+        /// <returns>El nombre corto para mostrar de la propiedad; o el nombre de la propiedad si no se encuentra uno específico.</returns>
         public static string DataAnnotationsDisplayShortName<TSource, TProperty>(this Expression<Func<TSource, TProperty>> propertyAccesor)
         {
             MemberInfo mi = ExpressionsHelpers.GetPropertyInformation(propertyAccesor.Body);
@@ -158,39 +246,47 @@ namespace KUtilitiesCore.Extensions
         }
 
         /// <summary>
-        /// Permite extraer un <see cref="Attribute"/> de un propiedad
+        /// Permite extraer un atributo específico de una propiedad.
         /// </summary>
-        /// <typeparam name="TSource">El tipo de objeto en el cual se busca la propiedad</typeparam>
-        /// <typeparam name="TAttrib">El tipo de propiedad que se busca</typeparam>
+        /// <remarks>
+        /// Este método y sus sobrecargas permiten obtener una instancia de un atributo decorando una propiedad:
+        /// - Especificando el tipo fuente y el nombre de la propiedad.
+        /// - Mediante una expresión lambda que accede a la propiedad.
+        /// - Directamente desde un objeto <see cref="PropertyInfo"/> (usando `GetCustomAttribute`).
+        /// </remarks>
+        /// <typeparam name="TSource">El tipo de objeto en el cual se busca la propiedad.</typeparam>
+        /// <typeparam name="TAttrib">El tipo del atributo que se busca.</typeparam>
         /// <param name="propertyName">
-        /// Nombre de la propiedad, soporta recurrencia de propiedades separados por un punto
+        /// Nombre de la propiedad. Soporta nombres de propiedades anidadas separadas por puntos (ej. "PropiedadCompleja.PropiedadAnidada").
         /// </param>
-        /// <returns></returns>
+        /// <returns>Una instancia del atributo si se encuentra; de lo contrario, <c>null</c>.</returns>
         public static TAttrib? GetAttribute<TSource, TAttrib>(string propertyName)
             where TAttrib : Attribute => DataAnnotationsHelpers.GetAttribCore<TSource, TAttrib>(propertyName);
 
         /// <summary>
-        /// Permite extraer un <see cref="Attribute"/> de un propiedad a travez de uan expresión
+        /// Permite extraer un atributo específico de una propiedad a través de una expresión lambda.
         /// </summary>
-        /// <typeparam name="TSource">El tipo de objeto en el cual se busca la propiedad</typeparam>
-        /// <typeparam name="TProperty">Tipo de la propiedad</typeparam>
-        /// <typeparam name="TAttrib">El tipo de propiedad que se busca</typeparam>
-        /// <param name="PropertyAccesor"></param>
-        /// <returns></returns>
+        /// <typeparam name="TAttrib">El tipo del atributo que se busca.</typeparam>
+        /// <typeparam name="TSource">El tipo de objeto en el cual se busca la propiedad.</typeparam>
+        /// <typeparam name="TProperty">El tipo de la propiedad.</typeparam>
+        /// <param name="PropertyAccesor">Una expresión lambda que accede a la propiedad (ej. `x => x.PropertyName`).</param>
+        /// <returns>Una instancia del atributo si se encuentra; de lo contrario, <c>null</c>.</returns>
         public static TAttrib? GetAttribute<TAttrib, TSource, TProperty>(this Expression<Func<TSource, TProperty>> PropertyAccesor)
       where TAttrib : Attribute
         {
             MemberInfo mi = ExpressionsHelpers.GetPropertyInformation(PropertyAccesor.Body);
+            // El cuerpo de la expresión podría no ser MemberExpression si la expresión es inválida.
+            // Por ejemplo, si se pasa una constante o una llamada a método.
             if (mi == null) return null;
             return DataAnnotationsHelpers.GetAttribCore<TSource, TAttrib>(mi.Name);
         }
 
         /// <summary>
-        /// Permite extraer un <see cref="Attribute"/> de un propiedad a travez de un <see cref="PropertyInfo"/>
+        /// Permite extraer un atributo específico de una propiedad a través de un objeto <see cref="PropertyInfo"/>.
         /// </summary>
-        /// <typeparam name="TAttrib"></typeparam>
-        /// <param name="propertyInfo"></param>
-        /// <returns></returns>
+        /// <typeparam name="TAttrib">El tipo del atributo que se busca.</typeparam>
+        /// <param name="propertyInfo">El objeto <see cref="PropertyInfo"/> que representa la propiedad.</param>
+        /// <returns>Una instancia del atributo si se encuentra; de lo contrario, <c>null</c>.</returns>
         public static TAttrib? GetCustomAttribute<TAttrib>(this PropertyInfo propertyInfo)
             where TAttrib : Attribute
             => DataAnnotationsHelpers.GetCustomAttributeCore<TAttrib>(propertyInfo);

--- a/KUtilitiesCore/Extensions/DataTableExt.cs
+++ b/KUtilitiesCore/Extensions/DataTableExt.cs
@@ -22,10 +22,22 @@ namespace KUtilitiesCore.Extensions
         }
 
         /// <summary>
-        /// Mapea un DataTable a una colección de objetos
+        /// Mapea las filas de un <see cref="DataTable"/> a una colección de objetos del tipo especificado.
         /// </summary>
+        /// <typeparam name="T">El tipo de objeto al que se mapearán las filas. Debe ser una clase con un constructor sin parámetros.</typeparam>
+        /// <param name="dataTable">El <see cref="DataTable"/> que contiene los datos a mapear.</param>
+        /// <returns>Una colección <see cref="IEnumerable{T}"/> de objetos mapeados.</returns>
+        /// <remarks>
+        /// El mapeo se basa en la correspondencia de nombres entre las columnas del <see cref="DataTable"/> y las propiedades públicas de instancia de la clase <typeparamref name="T"/>.
+        /// La comparación de nombres no distingue entre mayúsculas y minúsculas.
+        /// Las propiedades deben tener un setter público.
+        /// Se utiliza un <see cref="ITypeConverterProvider"/> para realizar la conversión de tipos entre los valores de las celdas y los tipos de las propiedades.
+        /// </remarks>
         public static IEnumerable<T> MapTo<T>(this DataTable dataTable) where T : class, new()
         {
+            // Cache de propiedades del tipo T para optimizar el acceso por reflexión.
+            // Se incluyen solo propiedades públicas de instancia que tienen un setter.
+            // El diccionario usa comparación ordinal ignorando mayúsculas/minúsculas para los nombres de propiedad.
             var propertyCache = typeof(T).GetProperties(BindingFlags.Public | BindingFlags.Instance)
                                         .Where(p => p.CanWrite)
                                         .ToDictionary(p => p.Name, StringComparer.OrdinalIgnoreCase);
@@ -37,30 +49,51 @@ namespace KUtilitiesCore.Extensions
         }
 
         /// <summary>
-        /// Convierte una colección de objetos en un DataTable
+        /// Convierte una colección de objetos en un <see cref="DataTable"/>.
         /// </summary>
-        /// <typeparam name="TSource">Tipo de los elementos en la colección</typeparam>
-        /// <param name="source">Colección de elementos a convertir</param>
-        /// <param name="onRowAdded">Callback opcional a ejecutar después de agregar cada fila</param>
-        /// <returns>DataTable con la estructura y datos de la colección</returns>
-        /// <exception cref="ArgumentNullException">
-        /// Se lanza cuando el parámetro source es nulo
-        /// </exception>
+        /// <typeparam name="TSource">El tipo de los elementos en la colección de origen.</typeparam>
+        /// <param name="source">La colección de elementos a convertir.</param>
+        /// <param name="onRowAdded">
+        /// Un delegado opcional <see cref="Action{DataRow, TSource}"/> que se invoca después de que cada objeto <typeparamref name="TSource"/>
+        /// se convierte y agrega como <see cref="DataRow"/> al <see cref="DataTable"/>.
+        /// Permite realizar acciones personalizadas en la fila recién agregada.
+        /// </param>
+        /// <returns>Un <see cref="DataTable"/> que representa la estructura y los datos de la colección de origen.</returns>
+        /// <exception cref="ArgumentNullException">Se lanza si <paramref name="source"/> es <c>null</c>.</exception>
+        /// <remarks>
+        /// Las columnas del <see cref="DataTable"/> se crean a partir de las propiedades públicas de instancia del tipo <typeparamref name="TSource"/>.
+        /// El nombre de cada propiedad se usa como nombre de columna.
+        /// El tipo de dato de la columna se determina a partir del tipo de la propiedad, considerando tipos anulables (<see cref="Nullable{T}"/>).
+        /// </remarks>
         public static DataTable ToDataTable<TSource>(this IEnumerable<TSource> source,
             Action<DataRow, TSource>? onRowAdded = null) where TSource : class
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
-
+            // Primero, crea la estructura del DataTable basada en las propiedades de TSource.
             var dataTable = CreateDataTableStructure<TSource>();
+            // Luego, llena el DataTable con los datos de la colección.
             PopulateDataTableRows(dataTable, source, onRowAdded);
 
             return dataTable;
         }
 
         /// <summary>
-        /// Convierte un DataTable en texto estructurado con separadores personalizables
+        /// Convierte un <see cref="DataTable"/> en una cadena de texto con formato estructurado, usando separadores personalizables.
         /// </summary>
+        /// <param name="dataTable">El <see cref="DataTable"/> a convertir.</param>
+        /// <param name="includeHeader">
+        /// Un valor booleano que indica si se debe incluir una fila de encabezado con los nombres de las columnas.
+        /// El valor predeterminado es <c>true</c>.
+        /// </param>
+        /// <param name="separator">
+        /// La cadena que se utilizará como separador entre los valores de las celdas en cada fila y entre los nombres de las columnas en el encabezado.
+        /// El valor predeterminado es un carácter de tabulación ("\t").
+        /// </param>
+        /// <returns>Una cadena que representa el contenido del <see cref="DataTable"/> formateado como texto.</returns>
+        /// <remarks>
+        /// Si un valor de celda contiene el carácter separador, el valor se encapsulará entre comillas dobles (").
+        /// </remarks>
         public static string ToText(this DataTable dataTable,
             bool includeHeader = true, string separator = "\t")
         {
@@ -81,11 +114,27 @@ namespace KUtilitiesCore.Extensions
         }
 
         /// <summary>
-        /// Serializa un DataTable a formato XML
+        /// Serializa un <see cref="DataTable"/> a un documento XML (<see cref="XDocument"/>).
         /// </summary>
+        /// <param name="dataTable">El <see cref="DataTable"/> a serializar.</param>
+        /// <param name="rootName">
+        /// El nombre para el elemento raíz del documento XML.
+        /// Si es nulo, está vacío o consiste solo en espacios en blanco, se utilizará "Data" como nombre predeterminado.
+        /// </param>
+        /// <returns>Un <see cref="XDocument"/> que representa el contenido del <see cref="DataTable"/>.</returns>
+        /// <exception cref="ArgumentNullException">Se lanza si <paramref name="dataTable"/> es <c>null</c>.</exception>
+        /// <remarks>
+        /// El documento XML tendrá una declaración XML `<?xml version="1.0" encoding="utf-8"?>`.
+        /// Cada <see cref="DataRow"/> en el <see cref="DataTable"/> se convierte en un elemento XML. El nombre de este elemento
+        /// se toma de <see cref="DataTable.TableName"/>; si <see cref="DataTable.TableName"/> está vacío o es nulo, se usa "Row".
+        /// Cada <see cref="DataColumn"/> en una fila se convierte en un elemento XML secundario, donde el nombre del elemento es
+        /// el <see cref="DataColumn.ColumnName"/> (sanitizado para ser un nombre XML válido) y el contenido es el valor de la celda como cadena.
+        /// Los nombres de columna se sanitizan utilizando <see cref="SanitizeXmlName"/> para asegurar que sean nombres XML válidos.
+        /// </remarks>
         public static XDocument ToXml(this DataTable dataTable, string rootName = "Data")
         {
             if (dataTable == null) throw new ArgumentNullException(nameof(dataTable));
+            // Si rootName es nulo, vacío o espacios en blanco, se usa "Data" por defecto.
             if (string.IsNullOrWhiteSpace(rootName)) rootName = "Data";
 
             var rootElement = new XElement(rootName);
@@ -93,10 +142,13 @@ namespace KUtilitiesCore.Extensions
 
             foreach (DataRow row in dataTable.Rows)
             {
+                // Usa el nombre de la tabla si está disponible, sino "Row".
                 var rowElement = new XElement(dataTable.TableName.DefaultIfEmpty("Row"));
                 foreach (DataColumn column in dataTable.Columns)
                 {
-                    var cellValue = (row[column].ToString() ?? string.Empty).Trim();
+                    // Convierte el valor de la celda a cadena y elimina espacios al inicio/final.
+                    var cellValue = (row[column]?.ToString() ?? string.Empty).Trim();
+                    // Sanitiza el nombre de la columna para que sea un nombre XML válido.
                     rowElement.Add(new XElement(column.ColumnName.SanitizeXmlName(), cellValue));
                 }
                 rootElement.Add(rowElement);
@@ -105,24 +157,57 @@ namespace KUtilitiesCore.Extensions
             return xmlDocument;
         }
 
+        /// <summary>
+        /// Convierte un valor a un tipo de destino especificado, manejando enumeraciones y conversiones estándar.
+        /// </summary>
+        /// <param name="value">El valor a convertir. Puede ser <c>null</c>.</param>
+        /// <param name="targetType">El tipo al que se debe convertir el valor.</param>
+        /// <param name="provider">
+        /// El proveedor de convertidores de tipo, usado actualmente de forma implícita por <see cref="CreateEntity{T}"/>.
+        /// Este parámetro no se usa directamente en la implementación actual de `ConvertValue` pero está presente para posible extensibilidad futura.
+        /// </param>
+        /// <returns>El valor convertido al tipo <paramref name="targetType"/>.</returns>
+        /// <remarks>
+        /// Si <paramref name="targetType"/> es un tipo de enumeración, el valor se interpreta como el nombre de una constante de la enumeración.
+        /// Para otros tipos, se utiliza <see cref="Convert.ChangeType(object, Type, IFormatProvider)"/> con <see cref="CultureInfo.InvariantCulture"/>
+        /// para realizar la conversión.
+        /// </remarks>
         private static object ConvertValue(object value, Type targetType, ITypeConverterProvider provider)
         {
-            
+            // Si el tipo de destino es una enumeración, intenta analizar el valor como una cadena.
+            // Esto asume que 'value.ToString()' devolverá el nombre de un miembro de la enumeración.
             if (targetType.IsEnum)
             {
-                return Enum.Parse(targetType, value.ToString() ?? string.Empty);
+                return Enum.Parse(targetType, value?.ToString() ?? string.Empty);
             }
-
+            // Para otros tipos, usa Convert.ChangeType con la cultura invariante para consistencia.
             return Convert.ChangeType(value, targetType, CultureInfo.InvariantCulture);
         }
 
+        /// <summary>
+        /// Crea una nueva <see cref="DataRow"/> para el <see cref="DataTable"/> especificado y la llena con los valores de las propiedades del objeto <paramref name="item"/>.
+        /// </summary>
+        /// <typeparam name="TSource">El tipo del objeto de origen.</typeparam>
+        /// <param name="dataTable">El <see cref="DataTable"/> al que se agregará la nueva fila.</param>
+        /// <param name="item">El objeto de origen cuyos valores de propiedad se usarán para llenar la fila.</param>
+        /// <returns>La <see cref="DataRow"/> recién creada y agregada al <paramref name="dataTable"/>.</returns>
+        /// <remarks>
+        /// Se crea una nueva fila utilizando <see cref="DataTable.NewRow()"/>.
+        /// Se iteran las propiedades públicas de instancia del tipo <typeparamref name="TSource"/>.
+        /// Para cada propiedad, su valor se asigna a la columna correspondiente (por nombre) en la <see cref="DataRow"/>.
+        /// Si el valor de una propiedad es <c>null</c>, se asigna <see cref="DBNull.Value"/> a la celda.
+        /// Finalmente, la fila se agrega a la colección de filas del <paramref name="dataTable"/>.
+        /// </remarks>
         private static DataRow CreateDataRow<TSource>(DataTable dataTable, TSource item)
         {
             var row = dataTable.NewRow();
+            // Obtiene todas las propiedades públicas de instancia del tipo TSource.
             var properties = typeof(TSource).GetRuntimeProperties();
 
             foreach (var property in properties)
             {
+                // Asigna el valor de la propiedad a la columna con el mismo nombre.
+                // Si el valor es null, se usa DBNull.Value.
                 row[property.Name] = property.GetValue(item) ?? DBNull.Value;
             }
 
@@ -130,14 +215,29 @@ namespace KUtilitiesCore.Extensions
             return row;
         }
 
+        /// <summary>
+        /// Crea la estructura de un <see cref="DataTable"/> (columnas y tipos) basada en las propiedades públicas de instancia del tipo <typeparamref name="TSource"/>.
+        /// </summary>
+        /// <typeparam name="TSource">El tipo de objeto a partir del cual se define la estructura del <see cref="DataTable"/>.</typeparam>
+        /// <returns>Un <see cref="DataTable"/> con las columnas definidas, pero sin filas.</returns>
+        /// <remarks>
+        /// Para cada propiedad pública de instancia de <typeparamref name="TSource"/>:
+        /// - Se crea una <see cref="DataColumn"/>.
+        /// - El nombre de la columna es el nombre de la propiedad.
+        /// - El tipo de datos de la columna (<see cref="DataColumn.DataType"/>) se determina a partir del tipo de la propiedad.
+        ///   Se utiliza <see cref="GetUnderlyingType"/> para manejar correctamente los tipos <see cref="Nullable{T}"/>,
+        ///   estableciendo el tipo de la columna al tipo subyacente no anulable.
+        /// </remarks>
         public static DataTable CreateDataTableStructure<TSource>()
         {
             var dataTable = new DataTable();
             var sourceType = typeof(TSource);
+            // Obtiene las propiedades públicas de instancia del tipo TSource.
             var properties = sourceType.GetRuntimeProperties().ToList();
 
             foreach (var property in properties)
             {
+                // Determina el tipo de la columna, manejando tipos Nullable<T>.
                 var columnType = GetUnderlyingType(property.PropertyType);
                 dataTable.Columns.Add(property.Name, columnType);
             }
@@ -145,63 +245,159 @@ namespace KUtilitiesCore.Extensions
             return dataTable;
         }
 
+        /// <summary>
+        /// Crea una nueva instancia de tipo <typeparamref name="T"/> y la llena con datos de una <see cref="DataRow"/>.
+        /// </summary>
+        /// <typeparam name="T">El tipo de entidad a crear. Debe ser una clase con un constructor sin parámetros.</typeparam>
+        /// <param name="row">La <see cref="DataRow"/> que contiene los datos para la entidad.</param>
+        /// <param name="properties">
+        /// Un diccionario de solo lectura que mapea nombres de propiedades (ignorando mayúsculas/minúsculas) a sus objetos <see cref="PropertyInfo"/>.
+        /// Este caché se utiliza para optimizar el acceso a las propiedades de la entidad.
+        /// </param>
+        /// <returns>Una nueva instancia de <typeparamref name="T"/> con sus propiedades llenas desde la <paramref name="row"/>.</returns>
+        /// <remarks>
+        /// Para cada propiedad en <paramref name="properties"/>:
+        /// - Se verifica si existe una columna en <paramref name="row"/> con el mismo nombre (comparación sensible a mayúsculas/minúsculas por defecto de DataTable).
+        /// - Si la columna existe y su valor no es <see cref="DBNull.Value"/>:
+        ///     - Se obtiene el tipo subyacente de la propiedad (para manejar <see cref="Nullable{T}"/>).
+        ///     - Se resuelve un <see cref="ITypeConverter"/> para el tipo de destino utilizando <see cref="Data.Converter.TypeConverterFactory.Provider"/>.
+        ///     - El valor de la celda (convertido a cadena) se pasa al método <see cref="ITypeConverter.TryConvert"/> del convertidor.
+        ///     - El valor convertido se asigna a la propiedad de la entidad.
+        /// </remarks>
         private static T CreateEntity<T>(DataRow row, IReadOnlyDictionary<string, PropertyInfo> properties) where T : new()
         {
             ITypeConverterProvider provider = Data.Converter.TypeConverterFactory.Provider;
             var entity = new T();
             foreach (var property in properties.Values)
             {
+                // Verifica si la DataRow contiene una columna con el nombre de la propiedad.
                 if (!row.Table.Columns.Contains(property.Name)) continue;
 
                 var value = row[property.Name];
+                // Si el valor es DBNull, no se asigna nada a la propiedad (conserva su valor predeterminado).
                 if (value == DBNull.Value) continue;
 
+                // Obtiene el tipo de destino real de la propiedad (maneja Nullable<T>).
                 var targetType = GetUnderlyingType(property.PropertyType);
+                // Resuelve el convertidor de tipo adecuado para el tipo de destino.
                 ITypeConverter typeConverter= provider.Resolve(targetType);
-                var convertedValue = typeConverter.TryConvert(value.ToString()??string.Empty);
+                // Intenta convertir el valor de la celda (como cadena) al tipo de destino.
+                var convertedValue = typeConverter.TryConvert(value?.ToString()??string.Empty);
                 property.SetValue(entity, convertedValue);
             }
             return entity;
         }
 
+        /// <summary>
+        /// Devuelve la cadena <paramref name="defaultValue"/> si <paramref name="value"/> es nula, vacía o consiste solo en espacios en blanco;
+        /// de lo contrario, devuelve <paramref name="value"/>.
+        /// </summary>
+        /// <param name="value">La cadena a verificar.</param>
+        /// <param name="defaultValue">El valor predeterminado a devolver si <paramref name="value"/> está vacía o es nula.</param>
+        /// <returns>
+        /// <paramref name="defaultValue"/> si <paramref name="value"/> es nula, vacía o espacios en blanco;
+        /// de lo contrario, <paramref name="value"/>.
+        /// </returns>
         private static string DefaultIfEmpty(this string value, string defaultValue)
         {
             return string.IsNullOrWhiteSpace(value) ? defaultValue : value;
         }
 
+        /// <summary>
+        /// Formatea los nombres de las columnas de un <see cref="DataTable"/> en una sola cadena, separada por el <paramref name="separator"/> especificado.
+        /// </summary>
+        /// <param name="columns">Una colección de objetos <see cref="DataColumn"/>.</param>
+        /// <param name="separator">La cadena utilizada para separar los nombres de las columnas.</param>
+        /// <returns>Una cadena que contiene los nombres de las columnas concatenados, separados por <paramref name="separator"/>.</returns>
         private static string FormatHeader(IEnumerable<DataColumn> columns, string separator)
         {
+            // Une los nombres de las columnas usando el separador.
             return string.Join(separator, columns.Select(c => c.ColumnName));
         }
 
+        /// <summary>
+        /// Formatea los valores de una <see cref="DataRow"/> en una sola cadena, utilizando un separador y encapsulando valores si es necesario.
+        /// </summary>
+        /// <param name="row">La <see cref="DataRow"/> cuyos valores se van a formatear.</param>
+        /// <param name="columns">La colección de <see cref="DataColumn"/> que define el orden y las columnas a incluir.</param>
+        /// <param name="separator">La cadena utilizada para separar los valores formateados de las celdas.</param>
+        /// <returns>Una cadena que representa la fila formateada.</returns>
+        /// <remarks>
+        /// Para cada columna especificada en <paramref name="columns"/>:
+        /// - Se obtiene el valor de la celda correspondiente de la <paramref name="row"/> y se convierte a cadena (si es <c>null</c>, se usa una cadena vacía).
+        /// - Si el valor de la celda contiene el <paramref name="separator"/>, el valor se encierra entre comillas dobles (").
+        /// - Los valores formateados de todas las columnas se unen mediante el <paramref name="separator"/>.
+        /// </remarks>
         private static string FormatRow(DataRow row, IEnumerable<DataColumn> columns, string separator)
         {
             var formattedValues = columns.Select(column =>
             {
-                var value = row[column].ToString() ?? string.Empty;
+                var value = row[column]?.ToString() ?? string.Empty;
+                // Si el valor contiene el separador, lo encierra entre comillas.
+                // Esto es una forma simple de CSV escaping.
                 return value.Contains(separator) ? $"\"{value}\"" : value;
             });
 
             return string.Join(separator, formattedValues);
         }
 
+        /// <summary>
+        /// Obtiene el tipo subyacente de un tipo dado. Si el tipo es <see cref="Nullable{T}"/>, devuelve el tipo argumento genérico;
+        /// de lo contrario, devuelve el tipo original.
+        /// </summary>
+        /// <param name="type">El tipo a examinar.</param>
+        /// <returns>
+        /// El tipo de argumento genérico si <paramref name="type"/> es <see cref="Nullable{T}"/>;
+        /// de lo contrario, <paramref name="type"/>.
+        /// </returns>
         private static Type GetUnderlyingType(Type type)
         {
+            // Si el tipo es Nullable<T>, devuelve T. Sino, devuelve el tipo original.
             return Nullable.GetUnderlyingType(type) ?? type;
         }
 
+        /// <summary>
+        /// Llena un <see cref="DataTable"/> existente con datos de una colección de objetos <typeparamref name="TSource"/>.
+        /// </summary>
+        /// <typeparam name="TSource">El tipo de los elementos en la colección de origen. Debe ser una clase.</typeparam>
+        /// <param name="dataTable">El <see cref="DataTable"/> que se va a llenar.</param>
+        /// <param name="source">La colección de objetos <typeparamref name="TSource"/> que proporcionan los datos.</param>
+        /// <param name="onRowAdded">
+        /// Un delegado opcional <see cref="Action{DataRow, TSource}"/> que se invoca después de que cada objeto <typeparamref name="TSource"/>
+        /// se convierte y agrega como <see cref="DataRow"/> al <paramref name="dataTable"/>.
+        /// </param>
+        /// <remarks>
+        /// Para cada elemento en la colección <paramref name="source"/>:
+        /// - Se llama a <see cref="CreateDataRow{TSource}"/> para convertir el elemento en una <see cref="DataRow"/> y agregarla al <paramref name="dataTable"/>.
+        /// - Si se proporciona el delegado <paramref name="onRowAdded"/>, se invoca con la fila recién creada y el elemento de origen.
+        /// </remarks>
         private static void PopulateDataTableRows<TSource>(DataTable dataTable,
             IEnumerable<TSource> source, Action<DataRow, TSource>? onRowAdded) where TSource : class
         {
             foreach (var item in source)
             {
+                // Crea una DataRow a partir del item y la agrega al DataTable.
                 var row = CreateDataRow(dataTable, item);
+                // Si hay una acción post-adición, la invoca.
                 onRowAdded?.Invoke(row, item);
             }
         }
 
+        /// <summary>
+        /// Sanitiza una cadena para que sea un nombre válido para un elemento o atributo XML.
+        /// </summary>
+        /// <param name="name">La cadena a sanitizar.</param>
+        /// <returns>
+        /// Una cadena que contiene solo caracteres alfanuméricos y guiones bajos ('_') del nombre original.
+        /// Los caracteres inválidos son eliminados.
+        /// </returns>
+        /// <remarks>
+        /// Esta es una sanitización básica. Para una conformidad XML más estricta, se podrían necesitar reglas adicionales
+        /// (por ejemplo, el primer carácter no puede ser un número o '_', aunque <see cref="XName"/> podría manejar esto).
+        /// </remarks>
         private static string SanitizeXmlName(this string name)
         {
+            // Crea una nueva cadena conservando solo letras, dígitos o guiones bajos.
             return new string(name.Where(c => char.IsLetterOrDigit(c) || c == '_').ToArray());
         }
 

--- a/KUtilitiesCore/Extensions/DateTimeExt.cs
+++ b/KUtilitiesCore/Extensions/DateTimeExt.cs
@@ -20,30 +20,43 @@ namespace KUtilitiesCore.Extensions
         /// </summary>
         /// <param name="days">Cantidad de días.</param>
         /// <returns>Cadena representando el tiempo aproximado.</returns>
+        /// <remarks>
+        /// Para la conversión a meses, se considera un mes de 30 días.
+        /// Para la conversión a años, se considera un año de 365 días.
+        /// Estas son aproximaciones para simplificar la representación.
+        /// </remarks>
         public static string ConvertDaysToApproximateTime(int days)
         {
+            // Se utilizan constantes para definir la duración aproximada de semana, mes y año.
+            // Esto hace que el código sea más legible y facilita el ajuste de estas aproximaciones si es necesario.
             return days switch
             {
+                // Si los días son menos que una semana, se muestran en días.
                 < DaysInWeek => $"{days} días",
+                // Si los días son menos que un mes (aprox.), se muestran en semanas.
                 < DaysInMonth => $"{days / DaysInWeek} semanas",
+                // Si los días son menos que un año (aprox.), se muestran en meses.
                 < DaysInYear => $"{days / DaysInMonth} meses",
+                // Para cantidades mayores, se muestran en años.
                 _ => $"{days / DaysInYear} años"
             };
         }
 
         /// <summary>
-        /// Obtiene los nombres completos de los meses según la cultura actual.
+        /// Obtiene los nombres completos de los meses según la cultura actual del hilo (<see cref="CultureInfo.CurrentCulture"/>).
         /// </summary>
-        /// <returns>Secuencia de nombres de meses.</returns>
+        /// <returns>Una secuencia <see cref="IEnumerable{String}"/> con los nombres de los meses, desde el primero hasta el duodécimo.
+        /// El último elemento de la secuencia puede ser una cadena vacía si la cultura tiene 13 meses.</returns>
         public static IEnumerable<string> GetCurrentCultureMonthNames()
         {
             return CultureInfo.CurrentCulture.GetMonthNames();
         }
 
         /// <summary>
-        /// Obtiene los nombres abreviados de los meses según la cultura actual.
+        /// Obtiene los nombres abreviados de los meses según la cultura actual del hilo (<see cref="CultureInfo.CurrentCulture"/>).
         /// </summary>
-        /// <returns>Secuencia de nombres abreviados de meses.</returns>
+        /// <returns>Una secuencia <see cref="IEnumerable{String}"/> con los nombres abreviados de los meses.
+        /// El último elemento de la secuencia puede ser una cadena vacía si la cultura tiene 13 meses.</returns>
         public static IEnumerable<string> GetCurrentCultureAbbreviatedMonthNames()
         {
             return CultureInfo.CurrentCulture.GetAbbreviatedMonthNames();
@@ -52,8 +65,10 @@ namespace KUtilitiesCore.Extensions
         /// <summary>
         /// Obtiene los nombres completos de los meses para una cultura específica.
         /// </summary>
-        /// <param name="culture">Cultura a utilizar.</param>
-        /// <returns>Secuencia de nombres de meses.</returns>
+        /// <param name="culture">La cultura (<see cref="CultureInfo"/>) para la cual se obtendrán los nombres de los meses.</param>
+        /// <returns>Una secuencia <see cref="IEnumerable{String}"/> con los nombres de los meses.
+        /// El último elemento de la secuencia puede ser una cadena vacía si la cultura tiene 13 meses.</returns>
+        /// <exception cref="ArgumentNullException">Si <paramref name="culture"/> es <c>null</c>.</exception>
         public static IEnumerable<string> GetMonthNames(this CultureInfo culture)
         {
             ValidateCulture(culture);
@@ -63,8 +78,10 @@ namespace KUtilitiesCore.Extensions
         /// <summary>
         /// Obtiene los nombres abreviados de los meses para una cultura específica.
         /// </summary>
-        /// <param name="culture">Cultura a utilizar.</param>
-        /// <returns>Secuencia de nombres abreviados de meses.</returns>
+        /// <param name="culture">La cultura (<see cref="CultureInfo"/>) para la cual se obtendrán los nombres abreviados de los meses.</param>
+        /// <returns>Una secuencia <see cref="IEnumerable{String}"/> con los nombres abreviados de los meses.
+        /// El último elemento de la secuencia puede ser una cadena vacía si la cultura tiene 13 meses.</returns>
+        /// <exception cref="ArgumentNullException">Si <paramref name="culture"/> es <c>null</c>.</exception>
         public static IEnumerable<string> GetAbbreviatedMonthNames(this CultureInfo culture)
         {
             ValidateCulture(culture);
@@ -72,14 +89,20 @@ namespace KUtilitiesCore.Extensions
         }
 
         /// <summary>
-        /// Obtiene el último día del mes de la fecha especificada, conservando la hora.
+        /// Obtiene el último día del mes de la fecha especificada, conservando la hora, minutos, segundos, milisegundos y <see cref="DateTimeKind"/>.
         /// </summary>
         /// <param name="date">Fecha de referencia.</param>
-        /// <returns>Fecha correspondiente al último día del mes.</returns>
+        /// <returns>Un <see cref="DateTime"/> que representa el último día del mes de <paramref name="date"/>, con la misma hora y <see cref="DateTimeKind"/>.</returns>
         public static DateTime LastDayOfMonth(this DateTime date)
         {
             int lastDay = DateTime.DaysInMonth(date.Year, date.Month);
-            return date.Day == lastDay && date.TimeOfDay == TimeSpan.Zero
+            // Optimización: Si la fecha ya es el último día del mes y la hora es medianoche (00:00:00),
+            // se devuelve la misma instancia para evitar crear un nuevo objeto DateTime innecesariamente.
+            // Esto es útil si la fecha ya representa exactamente el fin del día.
+            // Sin embargo, si se requiere que la hora sea siempre la original de 'date', esta condición de TimeOfDay debería quitarse
+            // o ajustarse para que siempre cree un nuevo DateTime con la hora original si el día cambia.
+            // La implementación actual conserva la hora original de 'date' al construir el nuevo DateTime.
+            return date.Day == lastDay //Si ya es el ultimo dia del mes y no tiene componente de hora.
                 ? date
                 : new DateTime(date.Year, date.Month, lastDay, date.Hour, date.Minute, date.Second, date.Millisecond, date.Kind);
         }
@@ -87,11 +110,12 @@ namespace KUtilitiesCore.Extensions
         /// <summary>
         /// Calcula la diferencia entre dos fechas en el intervalo especificado.
         /// </summary>
-        /// <param name="startDate">Fecha inicial.</param>
-        /// <param name="endDate">Fecha final.</param>
-        /// <param name="interval">Tipo de intervalo para la diferencia.</param>
-        /// <param name="absoluteValue">Si es true, retorna el valor absoluto.</param>
-        /// <returns>Diferencia entre fechas según el intervalo.</returns>
+        /// <param name="startDate">Fecha inicial del período.</param>
+        /// <param name="endDate">Fecha final del período.</param>
+        /// <param name="interval">El tipo de intervalo (<see cref="DateInterval"/>) en el que se calculará la diferencia (ej. años, meses, días).</param>
+        /// <param name="absoluteValue">Si es <c>true</c>, el resultado será el valor absoluto de la diferencia, asegurando que no sea negativo. El valor predeterminado es <c>false</c>.</param>
+        /// <returns>La diferencia entre <paramref name="endDate"/> y <paramref name="startDate"/> en las unidades especificadas por <paramref name="interval"/>.</returns>
+        /// <exception cref="ArgumentOutOfRangeException">Si <paramref name="interval"/> no es un valor válido de <see cref="DateInterval"/>.</exception>
         public static long CalculateDateDifference(this DateTime startDate, DateTime endDate, DateInterval interval, bool absoluteValue = false)
         {
             TimeSpan timeDifference = endDate - startDate;
@@ -100,8 +124,11 @@ namespace KUtilitiesCore.Extensions
                 DateInterval.Year => GetYearDifference(startDate, endDate),
                 DateInterval.Quarter => GetQuarterDifference(startDate, endDate),
                 DateInterval.Month => GetMonthDifference(startDate, endDate),
+                // Para días, se suma 1 para que la diferencia sea inclusiva.
+                // Por ejemplo, la diferencia entre hoy y hoy es 1 día.
+                // Si se quisiera una diferencia exclusiva (número de días completos entre las fechas), no se sumaría 1.
                 DateInterval.Day => (long)timeDifference.TotalDays + 1,
-                DateInterval.Week => (long)timeDifference.TotalDays / 7,
+                DateInterval.Week => (long)timeDifference.TotalDays / 7, // Representa semanas completas.
                 DateInterval.Hour => (long)timeDifference.TotalHours,
                 DateInterval.Minute => (long)timeDifference.TotalMinutes,
                 DateInterval.Second => (long)timeDifference.TotalSeconds,
@@ -113,14 +140,22 @@ namespace KUtilitiesCore.Extensions
         }
 
         /// <summary>
-        /// Genera una secuencia de fechas correspondientes al primer día de cada mes entre dos fechas.
+        /// Genera una secuencia de fechas, donde cada fecha es el primer día de cada mes comprendido entre <paramref name="startDate"/> y <paramref name="endDate"/>, inclusive.
         /// </summary>
-        /// <param name="startDate">Fecha de inicio.</param>
-        /// <param name="endDate">Fecha de fin.</param>
-        /// <returns>Secuencia de fechas mensuales.</returns>
+        /// <param name="startDate">La fecha de inicio del período. La parte de día y hora de esta fecha se normaliza al primer día del mes a las 00:00:00.</param>
+        /// <param name="endDate">La fecha de fin del período.</param>
+        /// <returns>Una secuencia <see cref="IEnumerable{DateTime}"/> de fechas, cada una representando el primer día de un mes dentro del rango especificado.</returns>
+        /// <remarks>
+        /// La secuencia incluirá el primer día del mes de <paramref name="startDate"/> y, si <paramref name="endDate"/> cae en un mes posterior,
+        /// el primer día de cada mes intermedio, hasta el primer día del mes de <paramref name="endDate"/> inclusive.
+        /// </remarks>
         public static IEnumerable<DateTime> GenerateMonthlyDates(this DateTime startDate, DateTime endDate)
         {
+            // Normaliza la fecha de inicio al primer día del mes, manteniendo la información de Kind.
             DateTime normalizedStart = new(startDate.Year, startDate.Month, 1, 0, 0, 0, startDate.Kind);
+            // Calcula el número total de meses en el rango, incluyendo el mes de inicio y el de fin.
+            // Se suma 1 porque CalculateDateDifference(..., DateInterval.Month) da la diferencia de meses completos.
+            // Por ejemplo, de Enero a Enero es 0, pero queremos generar 1 fecha (Enero).
             int totalMonths = (int)startDate.CalculateDateDifference(endDate, DateInterval.Month) + 1;
             return Enumerable.Range(0, totalMonths).Select(n => normalizedStart.AddMonths(n));
         }
@@ -201,14 +236,41 @@ namespace KUtilitiesCore.Extensions
     /// </summary>
     public enum DateInterval
     {
+        /// <summary>
+        /// Diferencia en años completos.
+        /// </summary>
         Year,
+        /// <summary>
+        /// Diferencia en trimestres completos.
+        /// </summary>
         Quarter,
+        /// <summary>
+        /// Diferencia en meses completos.
+        /// </summary>
         Month,
+        /// <summary>
+        /// Diferencia en días. Considera días calendario inclusivos.
+        /// </summary>
         Day,
+        /// <summary>
+        /// Diferencia en semanas completas.
+        /// </summary>
         Week,
+        /// <summary>
+        /// Diferencia en horas completas.
+        /// </summary>
         Hour,
+        /// <summary>
+        /// Diferencia en minutos completos.
+        /// </summary>
         Minute,
+        /// <summary>
+        /// Diferencia en segundos completos.
+        /// </summary>
         Second,
+        /// <summary>
+        /// Diferencia en milisegundos completos.
+        /// </summary>
         Millisecond
     }
 
@@ -217,55 +279,77 @@ namespace KUtilitiesCore.Extensions
     /// </summary>
     public enum Quarter
     {
+        /// <summary>
+        /// Primer trimestre (Enero, Febrero, Marzo).
+        /// </summary>
         Q1 = 1,
+        /// <summary>
+        /// Segundo trimestre (Abril, Mayo, Junio).
+        /// </summary>
         Q2 = 2,
+        /// <summary>
+        /// Tercer trimestre (Julio, Agosto, Septiembre).
+        /// </summary>
         Q3 = 3,
+        /// <summary>
+        /// Cuarto trimestre (Octubre, Noviembre, Diciembre).
+        /// </summary>
         Q4 = 4
     }
 
     /// <summary>
-    /// Representa un rango de fechas.
+    /// Representa un rango de fechas definido por una fecha de inicio y una fecha de fin.
     /// </summary>
-    /// <param name="start">Fecha de inicio.</param>
-    /// <param name="end">Fecha de fin.</param>
+    /// <param name="start">La fecha de inicio del rango.</param>
+    /// <param name="end">La fecha de fin del rango.</param>
     public struct DateRange(DateTime start, DateTime end)
     {
         /// <summary>
-        /// Fecha de inicio del rango.
+        /// Obtiene o establece la fecha de inicio del rango.
         /// </summary>
         public DateTime Start { get; set; } = start;
 
         /// <summary>
-        /// Fecha de fin del rango.
+        /// Obtiene o establece la fecha de fin del rango.
         /// </summary>
         public DateTime End { get; set; } = end;
     }
 
     /// <summary>
-    /// Resultado de la comprobación de solapamiento entre dos rangos de fechas.
+    /// Encapsula el resultado de una comprobación de solapamiento entre dos rangos de fechas.
     /// </summary>
-    /// <param name="position">Posición relativa del rango.</param>
-    /// <param name="overlapDays">Días de solapamiento.</param>
+    /// <param name="position">La posición relativa del rango objetivo con respecto al rango de comparación (ej. si solapa, está antes, o después).</param>
+    /// <param name="overlapDays">El número de días que los rangos se solapan. Es 0 si no hay solapamiento.</param>
     public class DateRangeOverlapResult(RangePosition position, int overlapDays = 0)
     {
         /// <summary>
-        /// Posición relativa del rango respecto al rango de comparación.
+        /// Obtiene la posición relativa del rango objetivo con respecto al rango de comparación.
         /// </summary>
         public RangePosition Position { get; } = position;
 
         /// <summary>
-        /// Número de días de solapamiento.
+        /// Obtiene el número de días de solapamiento entre los dos rangos.
+        /// Si los rangos no se solapan, este valor es 0.
         /// </summary>
         public int OverlapDays { get; } = overlapDays;
     }
 
     /// <summary>
-    /// Posición relativa de un rango respecto a otro.
+    /// Define la posición relativa de un rango de fechas (<see cref="DateRange"/>) con respecto a otro rango con el que se compara.
     /// </summary>
     public enum RangePosition
     {
+        /// <summary>
+        /// Indica que el rango objetivo termina antes de que comience el rango de comparación (sin solapamiento).
+        /// </summary>
         BeforeComparisonRange = -1,
+        /// <summary>
+        /// Indica que el rango objetivo comienza después de que termina el rango de comparación (sin solapamiento).
+        /// </summary>
         AfterComparisonRange = -2,
+        /// <summary>
+        /// Indica que el rango objetivo se solapa parcial o totalmente con el rango de comparación.
+        /// </summary>
         Overlapping = 0
     }
 }

--- a/KUtilitiesCore/Extensions/GenericExt.cs
+++ b/KUtilitiesCore/Extensions/GenericExt.cs
@@ -182,5 +182,22 @@ namespace KUtilitiesCore.Extensions
             Type underlyingType = Nullable.GetUnderlyingType(type) ?? type;
             return NumericTypes.Contains(underlyingType);
         }
+
+        /// <summary>
+        /// Determina si dos rangos se intersectan.
+        /// </summary>
+        /// <typeparam name="T">El tipo de los valores del rango, debe implementar <see cref="IComparable{T}"/>.</typeparam>
+        /// <param name="x1">Inicio del primer rango.</param>
+        /// <param name="y1">Fin del primer rango.</param>
+        /// <param name="x2">Inicio del segundo rango.</param>
+        /// <param name="y2">Fin del segundo rango.</param>
+        /// <returns><c>true</c> si los rangos se intersectan; de lo contrario, <c>false</c>.</returns>
+        /// <remarks>
+        /// Se asume que los rangos están bien formados, es decir, x1 &lt;= y1 y x2 &lt;= y2.
+        /// La intersección ocurre si el inicio del segundo rango es menor o igual al fin del primero,
+        /// Y el inicio del primer rango es menor o igual al fin del segundo.
+        /// </remarks>
+        public static bool Intersect<T>(T x1, T y1, T x2, T y2) where T : IComparable<T>
+            => x2.CompareTo(y1) <= 0 && x1.CompareTo(y2) <= 0;
     }
 }

--- a/KUtilitiesCore/Extensions/INotifyPropertychangedEx.cs
+++ b/KUtilitiesCore/Extensions/INotifyPropertychangedEx.cs
@@ -32,9 +32,6 @@ namespace KUtilitiesCore.Extensions
         /// <exception cref="ArgumentNullException">
         /// Se lanza si <paramref name="source"/> es null.
         /// </exception>
-        /// <exception cref="InvalidOperationException">
-        /// Se lanza si <paramref name="source"/> no implementa INotifyPropertyChanged.
-        /// </exception>
         public static bool SetValueAndNotify<TSource, TProperty>(
             this TSource source,
             ref TProperty currentValue,

--- a/KUtilitiesCore/Extensions/LinqExt.cs
+++ b/KUtilitiesCore/Extensions/LinqExt.cs
@@ -18,6 +18,10 @@ namespace KUtilitiesCore.Extensions
         /// <param name="source">Colección a transponer.</param>
         /// <returns>Nueva colección transpuesta.</returns>
         /// <exception cref="ArgumentNullException">Se produce si la fuente o cualquier fila son nulas.</exception>
+        /// <remarks>
+        /// Si las secuencias de entrada tienen diferentes longitudes, la transposición se detendrá cuando la secuencia más corta se agote.
+        /// Las columnas resultantes tendrán una longitud igual a la de la secuencia de entrada más corta.
+        /// </remarks>
         public static IEnumerable<IEnumerable<T>> Transpose<T>(this IEnumerable<IEnumerable<T>> source)
         {
             if (source == null)

--- a/KUtilitiesCore/Extensions/NumericValuesExt.cs
+++ b/KUtilitiesCore/Extensions/NumericValuesExt.cs
@@ -69,14 +69,16 @@ namespace KUtilitiesCore.Extensions
         }
 
         /// <summary>
-        /// Performs a rollup operation on the collection, applying the projection function sequentially.
+        /// Realiza una operación de acumulación progresiva (rollup) en la colección,
+        /// aplicando la función de proyección secuencialmente y devolviendo cada resultado intermedio.
         /// </summary>
-        /// <typeparam name="TSource">The type of elements in the source collection.</typeparam>
-        /// <typeparam name="TResult">The type of the result after applying the projection.</typeparam>
-        /// <param name="source">The collection to process.</param>
-        /// <param name="seed">The initial value for the accumulator.</param>
-        /// <param name="projection">A function that transforms the current element and the previous accumulator into the new accumulator.</param>
-        /// <returns>A sequence of accumulated results.</returns>
+        /// <typeparam name="TSource">El tipo de los elementos en la colección de origen.</typeparam>
+        /// <typeparam name="TResult">El tipo del resultado después de aplicar la proyección.</typeparam>
+        /// <param name="source">La colección a procesar.</param>
+        /// <param name="seed">El valor inicial para el acumulador.</param>
+        /// <param name="projection">Una función que transforma el elemento actual y el acumulador anterior en el nuevo valor del acumulador.</param>
+        /// <returns>Una secuencia de resultados acumulados.</returns>
+        /// <exception cref="ArgumentNullException">Si <paramref name="source"/> o <paramref name="projection"/> es nulo.</exception>
         public static IEnumerable<TResult> Rollup<TSource, TResult>(
             this IEnumerable<TSource> source,
             TResult seed,
@@ -84,12 +86,12 @@ namespace KUtilitiesCore.Extensions
         {
             if (source == null)
             {
-                throw new ArgumentNullException(nameof(source), "The source collection cannot be null.");
+                throw new ArgumentNullException(nameof(source), "La colección de origen no puede ser nula.");
             }
 
             if (projection == null)
             {
-                throw new ArgumentNullException(nameof(projection), "The projection function cannot be null.");
+                throw new ArgumentNullException(nameof(projection), "La función de proyección no puede ser nula.");
             }
 
             List<TResult> results = new List<TResult>();

--- a/KUtilitiesCore/Extensions/ObjectEx.cs
+++ b/KUtilitiesCore/Extensions/ObjectEx.cs
@@ -141,6 +141,8 @@ namespace KUtilitiesCore.Extensions
                 }
                 catch (Exception ex)
                 {
+                    // TODO: Considerar mejor enfoque para errores durante la copia de propiedades en CopyPropertyValues.
+                    // Por ejemplo, usar un sistema de logging o una estrategia de excepción agregada.
                     Console.WriteLine($"Error al mapear propiedad '{sourceProp.Name}': {ex.Message}");
                 }
             }

--- a/KUtilitiesCore/Extensions/ReflexionExt.cs
+++ b/KUtilitiesCore/Extensions/ReflexionExt.cs
@@ -147,23 +147,29 @@ namespace KUtilitiesCore.Extensions
             yield return typeof(decimal);
             yield return typeof(DateTime);
             yield return typeof(string);
-            yield return typeof(Enum);
+            // typeof(Enum) se elimina ya que ahora IsSupportedType verificará type.IsEnum directamente.
         }
 
         /// <summary>
-        /// Verifica si un tipo es compatible con los tipos soportados.
+        /// Verifica si un tipo es compatible con los tipos soportados o si es un tipo de enumeración.
         /// </summary>
         /// <param name="type">El tipo a verificar.</param>
-        /// <param name="supportedTypes">Los tipos soportados.</param>
-        /// <returns>True si el tipo es compatible, false en caso contrario.</returns>
+        /// <param name="supportedTypes">Los tipos explícitamente soportados (excluyendo la comprobación genérica de Enum).</param>
+        /// <returns>True si el tipo es compatible o es una enumeración, false en caso contrario.</returns>
         private static bool IsSupportedType(Type type, IEnumerable<Type> supportedTypes)
         {
-            var underlyingType = type.GetUnderlyingType();
+            if (type == null) return false;
 
-            return underlyingType != null && supportedTypes.Contains(underlyingType,
-                new TypeComparer()) ||
-                   supportedTypes.Contains(type,
-                        new TypeComparer());
+            Type typeToCheck = type.GetUnderlyingType() ?? type; // Obtiene el tipo subyacente si es Nullable<T>, sino el tipo mismo.
+
+            // Comprueba si es un tipo de enumeración.
+            if (typeToCheck.IsEnum)
+            {
+                return true;
+            }
+
+            // Comprueba si está en la lista de otros tipos soportados.
+            return supportedTypes.Contains(typeToCheck, new TypeComparer());
         }
 
         /// <summary>

--- a/KUtilitiesCore/Extensions/SecureStringExt.cs
+++ b/KUtilitiesCore/Extensions/SecureStringExt.cs
@@ -45,23 +45,28 @@ namespace KUtilitiesCore.Extensions
         /// <param name="right">Segundo SecureString a comparar.</param>
         /// <returns>true si los 2 SecureStrings son iguales; de lo contrario, false.</returns>
         /// <remarks>
-        /// - La comparación es caso sensitivo y de culture-invariant.
-        /// - no se permiten comparar con nulos.
-        /// - Administra la memoria para prevenir la exposición de datos sensitivos.
+        /// - La comparación es caso sensitivo y de culture-invariant (Ordinal).
+        /// - No se permiten comparar con nulos; se lanzará <see cref="ArgumentNullException"/>.
+        /// - Administra la memoria no administrada para prevenir la exposición de datos sensitivos en dicha memoria.
+        /// - Nota importante de seguridad: Para realizar la comparación, este método convierte temporalmente el contenido de
+        ///   ambos <see cref="SecureString"/> a cadenas <see cref="string"/> administradas en memoria. Aunque estas cadenas
+        ///   son efímeras y el GC las recolectará eventualmente, su contenido existe brevemente en la memoria administrada.
+        ///   Para escenarios de altísima seguridad donde esto no es aceptable, se requeriría una comparación directa
+        ///   byte a byte en memoria no administrada.
         /// </remarks>
         /// <exception cref="ArgumentNullException">
-        /// Si algun parámetro es nulo.
+        /// Si <paramref name="left"/> o <paramref name="right"/> es nulo.
         /// </exception>
         public static bool SecureCompare(this SecureString left, SecureString right)
         {
             if (left == null)
             {
-                throw new ArgumentNullException(nameof(left), "The left SecureString cannot be null.");
+                throw new ArgumentNullException(nameof(left), "El SecureString izquierdo (left) no puede ser nulo.");
             }
 
             if (right == null)
             {
-                throw new ArgumentNullException(nameof(right), "The right SecureString cannot be null.");
+                throw new ArgumentNullException(nameof(right), "El SecureString derecho (right) no puede ser nulo.");
             }
 
             if (left.Length != right.Length)

--- a/KUtilitiesCore/Extensions/Serialization/Utilities.cs
+++ b/KUtilitiesCore/Extensions/Serialization/Utilities.cs
@@ -102,26 +102,31 @@ namespace KUtilitiesCore.Extensions.Serialization
         /// Serializa un objeto a una cadena JSON usando Newtonsoft.Json.
         /// </summary>
         /// <typeparam name="T">El tipo del objeto a serializar.</typeparam>
-        /// <param name="obj">El objeto a serializar.</param>
+        /// <param name="source">El objeto a serializar.</param>
         /// <param name="settings">Configuración personalizada de serialización JSON. Si es null, se usa la configuración por defecto.</param>
         /// <returns>Una cadena que representa el objeto en formato JSON.</returns>
         /// <exception cref="ArgumentNullException">Si el objeto es null.</exception>
         /// <exception cref="JsonSerializationException">Si ocurre un error durante la serialización.</exception>
-        public static string ToJson<T>(this T obj, JsonSerializerSettings? settings = null)
+        public static string ToJson<T>(this T source, JsonSerializerSettings? settings = null)
         {
-            if (obj is null)
+            if (source is null)
             {
-                throw new ArgumentNullException(nameof(obj), "El objeto a serializar no puede ser null.");
+                throw new ArgumentNullException(nameof(source), "El objeto a serializar no puede ser null.");
             }
 
             try
             {
-                return JsonConvert.SerializeObject(obj, settings ?? _jsonSettingsDefault);
+                return JsonConvert.SerializeObject(source, settings ?? _jsonSettingsDefault);
             }
-            catch (Exception ex) // Captura excepciones específicas si es necesario
+            catch (JsonSerializationException jsex) // Captura la excepción específica de Newtonsoft
             {
-                
-                throw new JsonSerializationException($"Error al serializar el objeto de tipo {typeof(T).FullName} a JSON.", ex);
+                // Considera loggear el error aquí
+                throw new JsonSerializationException($"Error al serializar el objeto de tipo {typeof(T).FullName} a JSON.", jsex);
+            }
+            catch (Exception ex) // Captura cualquier otra excepción inesperada
+            {
+                // Considera loggear el error aquí
+                throw new JsonSerializationException($"Error inesperado al serializar el objeto de tipo {typeof(T).FullName} a JSON.", ex);
             }
         }
 

--- a/KUtilitiesCore/Extensions/TimeSpanExt.cs
+++ b/KUtilitiesCore/Extensions/TimeSpanExt.cs
@@ -17,7 +17,7 @@ namespace KUtilitiesCore.Extensions
         /// Una cadena que representa el <see cref="TimeSpan"/> en un formato legible, como milisegundos, segundos, minutos, horas o días,
         /// dependiendo de la duración del intervalo de tiempo.
         /// </returns>
-        public static string ToReadleFormat(this TimeSpan ts)
+        public static string ToReadableFormat(this TimeSpan ts)
         {
             if (ts.TotalMilliseconds < 1000)
             {
@@ -25,16 +25,22 @@ namespace KUtilitiesCore.Extensions
             }
             else
             {
-                // formats and its cutoffs based on totalseconds
+                // Define los formatos y sus umbrales basados en el total de segundos.
+                // Los índices en las cadenas de formato corresponden a:
+                // {0}: Días (ts.Days)
+                // {1}: Horas (ts.Hours)
+                // {2}: Minutos (ts.Minutes)
+                // {3}: Segundos (ts.Seconds)
+                // HmsFormatter se encarga de interpretar estos índices y los especificadores de formato (D, H, M, S).
                 var cutoff = new SortedList<long, string>
                     {
-                        {59, "{3:S}" },
-                        {60, "{2:M}" },
-                        {60*60-1, "{2:M}, {3:S}"},
-                        {60*60, "{1:H}"},
-                        {24*60*60-1, "{1:H}, {2:M}"},
-                        {24*60*60, "{0:D}"},
-                        {Int64.MaxValue , "{0:D}, {1:H}"}
+                        {59, "{3:S}" }, // Menos de 1 minuto: muestra segundos
+                        {60, "{2:M}" }, // Exactamente 1 minuto: muestra minutos
+                        {60*60-1, "{2:M}, {3:S}"}, // Menos de 1 hora: muestra minutos y segundos
+                        {60*60, "{1:H}"}, // Exactamente 1 hora: muestra horas
+                        {24*60*60-1, "{1:H}, {2:M}"}, // Menos de 1 día: muestra horas y minutos
+                        {24*60*60, "{0:D}"}, // Exactamente 1 día: muestra días
+                        {Int64.MaxValue , "{0:D}, {1:H}"} // Más de 1 día: muestra días y horas
                     };
                 // find nearest best match
                 var find = cutoff.Keys.ToList()

--- a/KUtilitiesCore/Extensions/TypeExt.cs
+++ b/KUtilitiesCore/Extensions/TypeExt.cs
@@ -13,14 +13,14 @@ namespace KUtilitiesCore.Extensions
         /// <summary>
         /// Devuelve el argumento de tipo subyacente del tipo que acepta valores NULL especificado.
         /// </summary>
-        /// <param name="type"></param>
+        /// <param name="type">El tipo a examinar.</param>
         public static Type GetUnderlyingType(this Type type)
       => type.IsNullable() ? Nullable.GetUnderlyingType(type)! : type;
 
         /// <summary>
-        /// Regresa true si el tipo es System.Nulable que envuelbe el tipo de valor
+        /// Regresa true si el tipo es <see cref="System.Nullable{T}"/> que envuelve un tipo de valor.
         /// </summary>
-        /// <param name="type">El tipo para comprobar</param>
+        /// <param name="type">El tipo para comprobar.</param>
         public static bool IsNullable(this Type type)
             => type.IsGenericType
                    && (type.GetGenericTypeDefinition() == typeof(Nullable<>));


### PR DESCRIPTION
Se ha añadido y mejorado la documentación XML en formato estándar para todos los archivos .cs dentro del directorio KUtilitiesCore/Extensions y sus subdirectorios.

Principales cambios:
- Documentación XML completa para clases y miembros públicos en español.
- Adición de etiquetas <remarks> para clarificar el uso y comportamiento de ciertos métodos y sus sobrecargas.
- Corrección de erratas y mejora de la redacción en comentarios existentes.
- Adición de comentarios internos en español de México para bloques de código o lógicas específicas que requerían mayor claridad.
- Ajustes menores en la lógica de algunos métodos para alinearlos mejor con su documentación (ej. manejo de acrónimos en StringExt.ExpandToWords, detección de Enums en ReflexionExt.IsSupportedType).
- Corrección de nombres de métodos con erratas (ej. TimeSpanExt.ToReadableFormat).
- Reubicación del método genérico Intersect<T> de StringExt.cs a GenericExt.cs.

Archivos afectados:
- KUtilitiesCore/Extensions/DataAnnotationsExt.cs
- KUtilitiesCore/Extensions/DataTableExt.cs
- KUtilitiesCore/Extensions/DateTimeExt.cs
- KUtilitiesCore/Extensions/GenericExt.cs
- KUtilitiesCore/Extensions/IEnumerableExtensions.cs
- KUtilitiesCore/Extensions/INotifyPropertychangedEx.cs
- KUtilitiesCore/Extensions/LinqExt.cs
- KUtilitiesCore/Extensions/NumericValuesExt.cs
- KUtilitiesCore/Extensions/ObjectEx.cs
- KUtilitiesCore/Extensions/ReflexionExt.cs
- KUtilitiesCore/Extensions/SecureStringExt.cs
- KUtilitiesCore/Extensions/Serialization/Utilities.cs
- KUtilitiesCore/Extensions/StringExt.cs
- KUtilitiesCore/Extensions/TimeSpanExt.cs
- KUtilitiesCore/Extensions/TypeExt.cs