### PR TITLE
Permitir especificaciones opcionales en repositorios

### DIFF
--- a/KUtilitiesCore.DataAccess/UOW/EfRepositoryBase.cs
+++ b/KUtilitiesCore.DataAccess/UOW/EfRepositoryBase.cs
@@ -54,19 +54,17 @@ namespace KUtilitiesCore.DataAccess.UOW
 
         // --- Implementación de IReadOnlyDbRepository<TEntity> ---
         /// <inheritdoc/>
-        public virtual async Task<TEntity> FindOneAsync(ISpecification<TEntity> specification)
+        public virtual async Task<TEntity> FindOneAsync(ISpecification<TEntity> specification = null)
         {
-            if (specification == null)
-                throw new ArgumentNullException(nameof(specification));
+            specification??=Specification<TEntity>.Empty;
             IQueryable<TEntity> query = ApplySpecification(specification);
             return await query.SingleOrDefaultAsync();
         }
 
         /// <inheritdoc/>
-        public virtual async Task<IReadOnlyList<TEntity>> FindAsync(ISpecification<TEntity> specification)
+        public virtual async Task<IReadOnlyList<TEntity>> FindAsync(ISpecification<TEntity> specification=null)
         {
-            if (specification == null)
-                throw new ArgumentNullException(nameof(specification));
+            specification ??= Specification<TEntity>.Empty;
             IQueryable<TEntity> query = ApplySpecification(specification);
             return await query.ToListAsync();
         }
@@ -74,12 +72,11 @@ namespace KUtilitiesCore.DataAccess.UOW
         /// <inheritdoc/>
         public virtual async Task<IPagedResult<TEntity>> GetPagedAsync(
             IPagingOptions pagingOptions,
-            ISpecification<TEntity> specification)
+            ISpecification<TEntity> specification=null)
         {
             if (pagingOptions == null)
                 throw new ArgumentNullException(nameof(pagingOptions));
-            if (specification == null)
-                throw new ArgumentNullException(nameof(specification));
+            specification ??= Specification<TEntity>.Empty;
             if (!pagingOptions.SkipPagination && pagingOptions.PageNumber <= 0)
                 throw new ArgumentOutOfRangeException(nameof(pagingOptions.PageNumber));
             if (!pagingOptions.SkipPagination && pagingOptions.PageSize <= 0)
@@ -159,18 +156,16 @@ namespace KUtilitiesCore.DataAccess.UOW
         }
 
         /// <inheritdoc/>
-        public virtual async Task<bool> ExistsAsync(ISpecification<TEntity> specification)
+        public virtual async Task<bool> ExistsAsync(ISpecification<TEntity> specification=null)
         {
-            if (specification == null)
-                throw new ArgumentNullException(nameof(specification));
+            specification ??= Specification<TEntity>.Empty;
             return await ApplySpecification(specification).AnyAsync();
         }
 
         /// <inheritdoc/>
-        public virtual async Task<int> CountAsync(ISpecification<TEntity> specification)
+        public virtual async Task<int> CountAsync(ISpecification<TEntity> specification=null)
         {
-            if (specification == null)
-                throw new ArgumentNullException(nameof(specification));
+            specification ??= Specification<TEntity>.Empty;
             return await ApplySpecification(specification).CountAsync();
         }
 

--- a/KUtilitiesCore.DataAccess/UOW/Interfaces/IReadOnlyDbRepository.cs
+++ b/KUtilitiesCore.DataAccess/UOW/Interfaces/IReadOnlyDbRepository.cs
@@ -20,7 +20,7 @@ namespace KUtilitiesCore.DataAccess.UOW.Interfaces
         /// <param name="specification">La especificación que define los criterios de búsqueda, inclusiones y ordenación.</param>
         /// <returns>La primera entidad que cumple la especificación, o null si no se encuentra ninguna.</returns>
         /// <exception cref="InvalidOperationException">Si más de una entidad cumple la especificación y se esperaba una sola.</exception>
-        Task<TEntity> FindOneAsync(ISpecification<TEntity> specification);
+        Task<TEntity> FindOneAsync(ISpecification<TEntity> specification = null);
 
         /// <summary>
         /// Busca una lista de entidades que cumplan con la especificación proporcionada de forma asíncrona.
@@ -28,7 +28,7 @@ namespace KUtilitiesCore.DataAccess.UOW.Interfaces
         /// </summary>
         /// <param name="specification">La especificación que define los criterios de búsqueda, inclusiones y ordenación.</param>
         /// <returns>Una lista de solo lectura de entidades que cumplen la especificación.</returns>
-        Task<IReadOnlyList<TEntity>> FindAsync(ISpecification<TEntity> specification);
+        Task<IReadOnlyList<TEntity>> FindAsync(ISpecification<TEntity> specification = null);
 
         /// <summary>
         /// Obtiene una página de resultados de entidades de forma asíncrona,
@@ -37,20 +37,20 @@ namespace KUtilitiesCore.DataAccess.UOW.Interfaces
         /// <param name="pagingOptions">Las opciones para la paginación (número de página, tamaño y si omitir paginación).</param>
         /// <param name="specification">La especificación que define los criterios, inclusiones y ordenación.</param>
         /// <returns>Un objeto IPagedResult con los datos de la página solicitada.</returns>
-        Task<IPagedResult<TEntity>> GetPagedAsync(IPagingOptions pagingOptions, ISpecification<TEntity> specification);
+        Task<IPagedResult<TEntity>> GetPagedAsync(IPagingOptions pagingOptions, ISpecification<TEntity> specification = null);
 
         /// <summary>
         /// Comprueba si existe alguna entidad que cumpla con la especificación proporcionada.
         /// </summary>
         /// <param name="specification">La especificación que define el criterio.</param>
         /// <returns>True si existe al menos una entidad, false en caso contrario.</returns>
-        Task<bool> ExistsAsync(ISpecification<TEntity> specification);
+        Task<bool> ExistsAsync(ISpecification<TEntity> specification = null);
 
         /// <summary>
         /// Cuenta el número de entidades que cumplen con la especificación proporcionada.
         /// </summary>
         /// <param name="specification">La especificación que define el criterio.</param>
         /// <returns>El número de entidades que cumplen la condición.</returns>
-        Task<int> CountAsync(ISpecification<TEntity> specification);
+        Task<int> CountAsync(ISpecification<TEntity> specification = null);
     }
 }


### PR DESCRIPTION
Se han modificado los métodos `FindOneAsync`, `FindAsync`, `GetPagedAsync`, `ExistsAsync` y `CountAsync` en las clases `EfRepositoryBase` y `IReadOnlyDbRepository` para que el parámetro `specification` sea opcional. Si no se proporciona una especificación, se utiliza `Specification<TEntity>.Empty` como valor por defecto, simplificando así su uso y eliminando la necesidad de lanzar excepciones por `null`.