### PR TITLE
Añade soporte para usuario en logs SQL y actualiza SqlClient

### DIFF
--- a/KUtilities.Logger/KUtilitiesCore.Logger.csproj
+++ b/KUtilities.Logger/KUtilitiesCore.Logger.csproj
@@ -11,6 +11,6 @@
 		<PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.5" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.5" />
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.5" />
-		<PackageReference Include="Microsoft.Data.SqlClient" Version="6.0.1" />
+		<PackageReference Include="Microsoft.Data.SqlClient" Version="7.0.0" />
 	</ItemGroup>
 </Project>

--- a/KUtilities.Logger/Options/SqlLoggerOptions.cs
+++ b/KUtilities.Logger/Options/SqlLoggerOptions.cs
@@ -32,5 +32,14 @@ namespace KUtilitiesCore.Logger.Options
         /// Nombre de la aplicación para identificar el origen de los logs.
         /// </summary>
         public string ApplicationName { get; set; } = "KUtilitiesApp";
+        /// <summary>
+        /// Obtiene o establece el delegado utilizado para resolver el identificador del usuario actual.
+        /// </summary>
+        /// <remarks>
+        /// El delegado debe devolver una cadena que represente al usuario, como un nombre de usuario o un ID de usuario.
+        /// Esta propiedad se puede configurar para personalizar la forma en que se recupera la información del usuario, por ejemplo, para integrarla con
+        /// sistemas de autenticación o proveedores de contexto de usuario.
+        /// </remarks>
+        public Func<string>? ResolveUser { get; set; }
     }
 }

--- a/KUtilities.Logger/SqlLogger.cs
+++ b/KUtilities.Logger/SqlLogger.cs
@@ -34,13 +34,14 @@ namespace KUtilitiesCore.Logger
         {
             try
             {
+                
                 using (var connection = new SqlConnection(LogOptions.ConnectionString))
                 {
                     connection.Open();
                     string query = $@"
                         INSERT INTO [{LogOptions.SchemaName}].[{LogOptions.TableName}] 
-                        ([Timestamp], [LogLevel], [Category], [EventId], [Message], [Exception], [ApplicationName])
-                        VALUES (@Timestamp, @LogLevel, @Category, @EventId, @Message, @Exception, @ApplicationName)";
+                        ([Timestamp], [LogLevel], [Category], [EventId], [UserName], [Message], [Exception], [ApplicationName])
+                        VALUES (@Timestamp, @LogLevel, @Category, @EventId, @UserName, @Message, @Exception, @ApplicationName)";
 
                     using (var command = new SqlCommand(query, connection))
                     {
@@ -54,6 +55,7 @@ namespace KUtilitiesCore.Logger
                         command.Parameters.AddWithValue("@LogLevel", entry.Level.ToString());
                         command.Parameters.AddWithValue("@Category", CategoryName);
                         command.Parameters.AddWithValue("@EventId", entry.Event.Id);
+                        command.Parameters.AddWithValue("@UserName", GetSafeResolveduser());
                         command.Parameters.AddWithValue("@Message", entry.Message ?? (object)DBNull.Value);
                         command.Parameters.AddWithValue("@Exception", exception);
                         command.Parameters.AddWithValue("@ApplicationName", LogOptions.ApplicationName);
@@ -66,6 +68,21 @@ namespace KUtilitiesCore.Logger
             {
                 System.Diagnostics.Debug.WriteLine($"Error al escribir en el registro SQL: {ex.Message}");
             }
+        }
+
+        private string GetSafeResolveduser()
+        {
+            string userName = string.Empty;
+
+            if (LogOptions.ResolveUser != null)
+            {
+                userName = LogOptions.ResolveUser(); // delegado configurable
+            }
+            else
+            {
+                userName = Environment.UserName; // fallback
+            }
+            return userName;
         }
 
         /// <inheritdoc/>
@@ -91,6 +108,7 @@ namespace KUtilitiesCore.Logger
                                     [LogLevel] [nvarchar](50) NOT NULL,
                                     [Category] [nvarchar](255) NOT NULL,
                                     [EventId] [int] NULL,
+                                    [UserName] [nvarchar](255) NULL,
                                     [Message] [nvarchar](max) NULL,
                                     [Exception] [nvarchar](max) NULL,
                                     [ApplicationName] [nvarchar](100) NULL


### PR DESCRIPTION
Se actualiza Microsoft.Data.SqlClient a la versión 7.0.0. Se incorpora la propiedad configurable ResolveUser en SqlLoggerOptions para personalizar el identificador de usuario. Se añade el campo UserName en la tabla de logs y en la inserción de registros, permitiendo registrar el usuario asociado a cada log.