### PR TITLE
 Se agregó MetadataHelper y actualizado DataErrorInfoExt.cs.

### DIFF
--- a/KUtilitiesCore/Data/DataErrorInfoExt.cs
+++ b/KUtilitiesCore/Data/DataErrorInfoExt.cs
@@ -40,6 +40,36 @@ namespace KUtilitiesCore.Data
         }
 
         /// <summary>
+        /// Valida el objeto completo usando DataAnnotations y MetadataType.
+        /// </summary>
+        /// <param name="source">El objeto a validar.</param>
+        /// <returns>Una lista de <see cref="ValidationResult"/> con los errores encontrados.</returns>
+        public static IList<ValidationResult> GetValidationResults(this object source)
+        {
+            if (source is null)
+                throw new ArgumentNullException(nameof(source));
+
+            var results = new List<ValidationResult>();
+            var context = new ValidationContext(source, serviceProvider: null, items: null);
+
+            try
+            {
+                // Registrar la clase de metadatos para que Validator la reconozca
+                MetadataHelper.RegisterMetadataClass(source.GetType());
+
+                // Ejecutar validación de DataAnnotations
+                Validator.TryValidateObject(source, context, results, validateAllProperties: true);
+            }
+            catch (Exception ex)
+            {
+                ex.Data.Add("Type", source.GetType().Name);
+                throw;
+            }
+
+            return results;
+        }
+
+        /// <summary>
         /// Verifica si un objeto que implementa IDataErrorInfo tiene errores.
         /// </summary>
         /// <param name="owner">El objeto que implementa IDataErrorInfo.</param>
@@ -120,11 +150,13 @@ namespace KUtilitiesCore.Data
         /// <returns>El validador de propiedades, o null si no se encuentra.</returns>
         private static PropertyValidator? GetPropertyValidator(Type type, string propertyName)
         {
-            var property = type.GetProperty(propertyName);
+            MetadataHelper.RegisterMetadataClass(type);
+            var property = TypeDescriptor.GetProperties(type)[propertyName];
+
             return property is null
                 ? null
                 : PropertyValidator
-                .CreateFromAttributes(GetAllAttributes(property).OfType<ValidationAttribute>(), propertyName);
+                .CreateFromAttributes(property.Attributes.OfType<ValidationAttribute>(), propertyName);
         }
 
         /// <summary>

--- a/KUtilitiesCore/Data/MetadataHelper.cs
+++ b/KUtilitiesCore/Data/MetadataHelper.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Collections.Concurrent;
+using System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+
+namespace KUtilitiesCore.Data
+{
+    /// <summary>
+    /// Clase interna de utilidad para registrar clases de metadatos asociadas mediante <see cref="MetadataTypeAttribute"/>.
+    /// </summary>
+    internal static class MetadataHelper
+    {
+        private static readonly ConcurrentDictionary<Type, Type?> MetaDataDictionary = new ConcurrentDictionary<Type, Type?>();
+
+        /// <summary>
+        /// Registra la clase de metadatos para el tipo de modelo especificado si tiene el atributo <see cref="MetadataTypeAttribute"/>.
+        /// </summary>
+        /// <param name="modelType">El tipo de la clase que se desea validar.</param>
+        public static void RegisterMetadataClass(Type modelType)
+        {
+            if (modelType == null) return;
+
+            // Intentamos obtener o agregar al diccionario para evitar registros duplicados costosos
+            MetaDataDictionary.GetOrAdd(modelType, type =>
+            {
+                var metadataType = GetMetadataType(type);
+                if (metadataType != null)
+                {
+                    // Registra el proveedor de descripción de tipos asociado a la clase de metadatos
+                    TypeDescriptor.AddProviderTransparent(
+                        new AssociatedMetadataTypeTypeDescriptionProvider(type, metadataType), 
+                        type);
+                }
+                return metadataType;
+            });
+        }
+
+        private static Type? GetMetadataType(Type type)
+        {
+            var attribute = (MetadataTypeAttribute?)type.GetCustomAttributes(typeof(MetadataTypeAttribute), true).FirstOrDefault();
+            return attribute?.MetadataClassType;
+        }
+    }
+}

--- a/KUtilitiesCoreTests/Data/DataErrorInfoExtTests.cs
+++ b/KUtilitiesCoreTests/Data/DataErrorInfoExtTests.cs
@@ -26,6 +26,21 @@ namespace KUtilitiesCore.Tests.Data
             public int Age { get; set; }
         }
 
+        [MetadataType(typeof(TestDataErrorInfo))]
+        private class TestDataWithoutAttributes : IDataErrorInfo
+        {
+            public string Error { get; set; }
+            public string this[string columnName]
+            {
+                get
+                {
+                    return DataErrorInfoExt.GetErrorText(this, columnName);
+                }
+            }
+            public string Name { get; set; }
+            public int Age { get; set; }
+        }
+
         [TestMethod]
         public void GetErrorText_ShouldReturnErrorForNonNestedProperty()
         {
@@ -37,6 +52,32 @@ namespace KUtilitiesCore.Tests.Data
 
             // Assert
             Assert.IsTrue(errorText.Length>0);
+        }
+
+        [TestMethod]
+        public void GetErrorText_ShouldGetValidationError()
+        {
+            // Arrange
+            var testObject = new TestDataErrorInfo { Name = "", Age = 300 };
+
+            // Act
+            var valresults= testObject.GetValidationResults();
+
+            // Assert
+            Assert.IsGreaterThan(0, valresults.Count);
+        }
+
+        [TestMethod]
+        public void UseMetaData_ShouldGetValidationError()
+        {
+            // Arrange
+            var testObject = new TestDataWithoutAttributes { Name = "", Age = 300 };
+
+            // Act
+            var valresults = testObject.GetValidationResults();
+
+            // Assert
+            Assert.IsGreaterThan(0, valresults.Count);
         }
 
         [TestMethod]


### PR DESCRIPTION
   1. Creado KUtilitiesCore/Data/MetadataHelper.cs: Clase interna que utiliza ConcurrentDictionary y AssociatedMetadataTypeTypeDescriptionProvider para registrar las clases de metadatos de forma segura y eficiente.
   2. Añadido GetValidationResults a DataErrorInfoExt: Método de extensión que permite validar un objeto completo, registrando automáticamente su clase de metadatos antes de ejecutar Validator.TryValidateObject.
   3. Actualizado GetPropertyValidator: Ahora utiliza TypeDescriptor.GetProperties(type)[propertyName], lo que garantiza que los atributos de validación definidos en la clase MetadataType sean detectados tanto para validaciones individuales (como las requeridas por IDataErrorInfo) como para validaciones globales.

  Con estos cambios, las clases que utilicen el atributo [MetadataType(typeof(MiMetadata))] serán validadas correctamente por todas las utilidades de la librería.