### PR TITLE
Optimización de notificación de propiedades

### DIFF
--- a/KUtilitiesCore/Extensions/INotifyPropertychangedEx.cs
+++ b/KUtilitiesCore/Extensions/INotifyPropertychangedEx.cs
@@ -1,37 +1,28 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
-using System.Linq;
-using System.Reflection;
 using System.Runtime.CompilerServices;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace KUtilitiesCore.Extensions
 {
     /// <summary>
-    /// Provee metodos de extension para objetos que implementen <see cref="INotifyPropertyChanged"/>
+    /// Provee métodos de extensión para objetos que implementen <see cref="INotifyPropertyChanged"/>.
     /// </summary>
+    /// <remarks>
+    /// Esta clase se mantiene por compatibilidad. Se recomienda utilizar <see cref="PropertyChangedExtensions"/>.
+    /// </remarks>
     public static class INotifyPropertychangedEx
     {
         /// <summary>
-        /// Actualiza la propiedad solo si el valor cambia e invoca
-        /// el método protegido OnPropertyChanged(string) si existe.
+        /// Actualiza la propiedad solo si el valor cambia e invoca el método OnPropertyChanged(string) si existe.
         /// </summary>
         /// <typeparam name="TSource">Tipo del objeto que implementa INotifyPropertyChanged.</typeparam>
         /// <typeparam name="TProperty">Tipo de la propiedad.</typeparam>
         /// <param name="source">Instancia origen.</param>
-        /// <param name="currentValue">Campo que almacena el valor actual.</param>
+        /// <param name="currentValue">Referencia al campo que almacena el valor actual.</param>
         /// <param name="newValue">Nuevo valor propuesto.</param>
-        /// <param name="propertyName">
-        /// Se completa automáticamente con el nombre del llamador.
-        /// </param>
-        /// <returns>
-        /// true si el valor cambió y se notificó; false si los valores eran iguales.
-        /// </returns>
-        /// <exception cref="ArgumentNullException">
-        /// Se lanza si <paramref name="source"/> es null.
-        /// </exception>
+        /// <param name="propertyName">Nombre de la propiedad (se obtiene automáticamente).</param>
+        /// <returns>true si el valor cambió y se notificó; false si los valores eran iguales.</returns>
         public static bool SetValueAndNotify<TSource, TProperty>(
             this TSource source,
             ref TProperty currentValue,
@@ -39,37 +30,8 @@ namespace KUtilitiesCore.Extensions
             [CallerMemberName] string propertyName = "")
             where TSource : class, INotifyPropertyChanged
         {
-            if (source is null)
-                throw new ArgumentNullException(nameof(source));
-
-            // Si no hay cambios, salir.
-            if (EqualityComparer<TProperty>.Default.Equals(currentValue, newValue))
-                return false;
-
-            // Asigna el nuevo valor.
-            currentValue = newValue;
-
-            // Busca OnPropertyChanged(string) mediante reflexión.
-            MethodInfo? onPropertyChanged =
-                GetMethodCore(typeof(TSource), "OnPropertyChanged");
-
-            // Invoca el método, si existe.
-            onPropertyChanged?.Invoke(source, new object[] { propertyName });
-
-            return true;
+            // Redirige a la implementación optimizada en PropertyChangedExtensions
+            return PropertyChangedExtensions.SetValue(source, ref currentValue, newValue, propertyName);
         }
-
-        /// <summary>
-        /// Devuelve el MethodInfo de un método de instancia (público o protegido)
-        /// cuyo nombre coincide con <paramref name="memberName"/>.
-        /// </summary>
-        private static MethodInfo? GetMethodCore(Type sourceType, string memberName) =>
-            sourceType.GetMethod(
-                memberName,
-                BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic,
-                binder: null,
-                types: new[] { typeof(string) },
-                modifiers: null);
     }
 }
-

--- a/KUtilitiesCore/Extensions/PropertyChangedExtensions.cs
+++ b/KUtilitiesCore/Extensions/PropertyChangedExtensions.cs
@@ -1,0 +1,80 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq.Expressions;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Collections.Concurrent;
+
+namespace KUtilitiesCore.Extensions
+{
+    /// <summary>
+    /// Provee métodos de extensión para optimizar la notificación de cambios en propiedades
+    /// mediante la implementación de <see cref="INotifyPropertyChanged"/>.
+    /// </summary>
+    public static class PropertyChangedExtensions
+    {
+        private static readonly ConcurrentDictionary<Type, Action<object, string>?> _onPropertyChangedCache = new();
+
+        /// <summary>
+        /// Establece el valor de una propiedad, comprueba si ha cambiado y notifica el cambio.
+        /// </summary>
+        /// <typeparam name="T">Tipo de la propiedad.</typeparam>
+        /// <param name="source">La instancia que implementa <see cref="INotifyPropertyChanged"/>.</param>
+        /// <param name="field">Referencia al campo subyacente que almacena el valor.</param>
+        /// <param name="newValue">El nuevo valor a asignar a la propiedad.</param>
+        /// <param name="propertyName">Nombre de la propiedad que cambió. Se obtiene automáticamente mediante <see cref="CallerMemberNameAttribute"/>.</param>
+        /// <returns>
+        /// <see langword="true"/> si el valor cambió y se realizó la notificación; 
+        /// <see langword="false"/> si el nuevo valor es igual al actual o si <paramref name="source"/> es nulo.
+        /// </returns>
+        public static bool SetValue<T>(
+            this INotifyPropertyChanged source,
+            ref T field,
+            T newValue,
+            [CallerMemberName] string propertyName = null!)
+        {
+            if (source == null) return false;
+
+            if (EqualityComparer<T>.Default.Equals(field, newValue))
+                return false;
+
+            field = newValue;
+            source.RaisePropertyChanged(propertyName);
+            return true;
+        }
+
+        /// <summary>
+        /// Notifica que una propiedad ha cambiado invocando el método 'OnPropertyChanged' de la instancia.
+        /// Utiliza una caché de delegados compilados para maximizar el rendimiento y evitar el costo de reflexión repetitiva.
+        /// </summary>
+        /// <param name="source">La instancia que dispara la notificación.</param>
+        /// <param name="propertyName">Nombre de la propiedad que ha cambiado.</param>
+        public static void RaisePropertyChanged(this INotifyPropertyChanged source, string propertyName)
+        {
+            if (source == null || string.IsNullOrEmpty(propertyName)) return;
+
+            var type = source.GetType();
+            var invoker = _onPropertyChangedCache.GetOrAdd(type, t =>
+            {
+                // Busca el método OnPropertyChanged(string) (puede ser protected o public)
+                var method = t.GetMethod("OnPropertyChanged",
+                    BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic,
+                    null, new[] { typeof(string) }, null);
+
+                if (method == null) return null;
+
+                // Generamos un delegado Action<object, string> compilado que llama al método específico del tipo.
+                // Esto es significativamente más rápido que method.Invoke().
+                var instanceParam = Expression.Parameter(typeof(object), "instance");
+                var nameParam = Expression.Parameter(typeof(string), "name");
+                var castInstance = Expression.Convert(instanceParam, t);
+                var call = Expression.Call(castInstance, method, nameParam);
+                
+                return Expression.Lambda<Action<object, string>>(call, instanceParam, nameParam).Compile();
+            });
+
+            invoker?.Invoke(source, propertyName);
+        }
+    }
+}


### PR DESCRIPTION
Se redirigió la funcionalidad de `INotifyPropertychangedEx` a una nueva clase `PropertyChangedExtensions` con métodos de extensión optimizados. Se eliminó código redundante y se mejoró el rendimiento mediante el uso de una caché de delegados compilados para invocar `OnPropertyChanged`.

Se añadieron métodos `SetValue` y `RaisePropertyChanged` en `PropertyChangedExtensions` para gestionar cambios de propiedades de forma más eficiente. Además, se corrigieron errores tipográficos y se mejoró la documentación XML.