### PR TITLE
feat(mvvm): Añadir compatibilidad con nombres de comandos y búsqueda …

### DIFF
--- a/KUtilitiesCore.MVVM/Command/Binder/EventCommandBinderCollection.cs
+++ b/KUtilitiesCore.MVVM/Command/Binder/EventCommandBinderCollection.cs
@@ -65,6 +65,9 @@ namespace KUtilitiesCore.MVVM.Command.Binder
         /// Enlaza de forma segura y desechable un evento de un objeto a un comando del ViewModel, usando una expresión de método sin parámetros.
         /// </summary>
         /// <typeparam name="T">Tipo del objeto que expone el evento.</typeparam>
+        /// <param name="commandName">
+        /// Establece el nombre asociado al comando
+        /// </param>
         /// <param name="targetObject">El objeto que expone el evento (ej. un control de UI).</param>
         /// <param name="eventExpression">
         /// Expresión lambda que identifica el evento a enlazar (ej. <c>c =&gt; c.Click</c>).
@@ -75,7 +78,7 @@ namespace KUtilitiesCore.MVVM.Command.Binder
         /// <param name="executeExpression">
         /// Expresión que representa el método a ejecutar en el ViewModel.
         /// </param>
-        public void BindCommand<T>(T targetObject, Expression<Func<T, Delegate>> eventExpression,
+        public void BindCommand<T>(string commandName,T targetObject, Expression<Func<T, Delegate>> eventExpression,
             Action<bool> targetStatus, Expression<Action<TViewModel>> executeExpression)
             where T : class
         {
@@ -83,7 +86,7 @@ namespace KUtilitiesCore.MVVM.Command.Binder
                 targetObject,
                 eventExpression,
                 targetStatus,
-                RelayCommand<TViewModel>.Create(_viewModel, executeExpression));
+                RelayCommand<TViewModel>.Create(_viewModel, commandName, executeExpression));
         }
 
         /// <summary>
@@ -95,6 +98,9 @@ namespace KUtilitiesCore.MVVM.Command.Binder
         /// <param name="eventExpression">
         /// Expresión lambda que identifica el evento a enlazar (ej. <c>c =&gt; c.Click</c>).
         /// </param>
+        /// <param name="commandName">
+        /// Establece el nombre asociado al comando
+        /// </param>
         /// <param name="targetStatus">
         /// Acción que establece el estado del objeto según si el comando puede ejecutarse.
         /// </param>
@@ -104,7 +110,7 @@ namespace KUtilitiesCore.MVVM.Command.Binder
         /// <param name="parameterPropertyExpression">
         /// Expresión que representa la propiedad del parámetro en el ViewModel.
         /// </param>
-        public void BindCommand<T, TParam>(T targetObject, Expression<Func<T, Delegate>> eventExpression,
+        public void BindCommand<T, TParam>(string commandName,T targetObject, Expression<Func<T, Delegate>> eventExpression,
             Action<bool> targetStatus, Expression<Action<TViewModel, TParam?>> executeExpression,
             Expression<Func<TViewModel, TParam>> parameterPropertyExpression)
             where T : class
@@ -113,7 +119,7 @@ namespace KUtilitiesCore.MVVM.Command.Binder
                 targetObject,
                 eventExpression,
                 targetStatus,
-                RelayCommand<TViewModel, TParam>.Create(_viewModel, executeExpression, parameterPropertyExpression));
+                RelayCommand<TViewModel, TParam>.Create(_viewModel, commandName, executeExpression, parameterPropertyExpression));
         }
 
         /// <summary>

--- a/KUtilitiesCore.MVVM/Command/RelayCommand.cs
+++ b/KUtilitiesCore.MVVM/Command/RelayCommand.cs
@@ -29,6 +29,10 @@ namespace KUtilitiesCore.MVVM.Command
 
         private Func<TParam?> _getParamDelegate = () => default;
 
+        public RelayCommand(string commandName) : base(commandName)
+        {
+        }
+
         #endregion Fields
 
         #region Properties
@@ -53,6 +57,7 @@ namespace KUtilitiesCore.MVVM.Command
         /// Crea un comando que ejecuta un método con parámetro en el ViewModel. La lógica
         /// CanExecute se busca por reflexión.
         /// </summary>
+        /// <param name="commandName">Texto que representa el comando</param>
         /// <param name="viewModel">Instancia del ViewModel.</param>
         /// <param name="executeExpression">Expresión que representa el método a ejecutar con parámetro.</param>
         /// <param name="parameterPropertyExpression">
@@ -63,10 +68,12 @@ namespace KUtilitiesCore.MVVM.Command
         /// Si viewModel, executeExpression o parameterPropertyExpression son nulos.
         /// </exception>
         public static RelayCommand<TViewModel, TParam> Create(
-            TViewModel viewModel,
+            TViewModel viewModel,string commandName,
             Expression<Action<TViewModel, TParam?>> executeExpression,
             Expression<Func<TViewModel, TParam>> parameterPropertyExpression)
         {
+            if (string.IsNullOrEmpty(commandName))
+                throw new ArgumentNullException(nameof(commandName));
             if (viewModel == null)
                 throw new ArgumentNullException(nameof(viewModel));
             if (executeExpression == null)
@@ -74,7 +81,7 @@ namespace KUtilitiesCore.MVVM.Command
             if (parameterPropertyExpression == null)
                 throw new ArgumentNullException(nameof(parameterPropertyExpression));
 
-            RelayCommand<TViewModel, TParam> relayCommand = new();
+            RelayCommand<TViewModel, TParam> relayCommand = new(commandName);
             relayCommand.InitializeMemberMetaData(viewModel, parameterPropertyExpression);
             relayCommand.InitializeCommandMetadata(executeExpression, expectedParameters: 1);
 
@@ -244,6 +251,10 @@ namespace KUtilitiesCore.MVVM.Command
         /// </summary>
         private Action? _executeAction;
 
+        public RelayCommand(string commandName) : base(commandName)
+        {
+        }
+
         #endregion Fields
 
         #region Methods
@@ -252,20 +263,23 @@ namespace KUtilitiesCore.MVVM.Command
         /// Crea un comando que ejecuta un método sin parámetros en el ViewModel. La lógica
         /// CanExecute se busca automáticamente por reflexión.
         /// </summary>
+        /// <param name="commandName">Texto que representa el comando</param>
         /// <param name="viewModel">Instancia del ViewModel.</param>
         /// <param name="executeExpression">Expresión que representa el método a ejecutar.</param>
         /// <returns>Instancia de RelayCommand configurada.</returns>
         /// <exception cref="ArgumentNullException">Si viewModel o executeExpression son nulos.</exception>
         public static RelayCommand<TViewModel> Create(
-            TViewModel viewModel,
+            TViewModel viewModel,string commandName,
             Expression<Action<TViewModel>> executeExpression)
         {
+            if (string.IsNullOrEmpty(commandName))
+                throw new ArgumentNullException(nameof(commandName));
             if (viewModel == null)
                 throw new ArgumentNullException(nameof(viewModel));
             if (executeExpression == null)
                 throw new ArgumentNullException(nameof(executeExpression));
 
-            RelayCommand<TViewModel> relayCommand = new();
+            RelayCommand<TViewModel> relayCommand = new(commandName);
             relayCommand.InitializeCommandMetadata(executeExpression, expectedParameters: 0);
 
             // Buscar el método CanExecute usando reflexión

--- a/KUtilitiesCore.MVVM/Command/RelayCommandBase.cs
+++ b/KUtilitiesCore.MVVM/Command/RelayCommandBase.cs
@@ -15,8 +15,9 @@ namespace KUtilitiesCore.MVVM.Command
         /// <summary>
         /// Inicializa una nueva instancia de la clase <see cref="RelayCommandBase"/>.
         /// </summary>
-        protected RelayCommandBase()
+        protected RelayCommandBase(string commandName)
         {
+            CommandName = commandName;
         }
 
         #endregion Constructors
@@ -31,7 +32,7 @@ namespace KUtilitiesCore.MVVM.Command
         #region Properties
 
         /// <inheritdoc/>
-        public virtual string CommandName { get; internal set; } = string.Empty;
+        public virtual string CommandName { get; internal set; }
 
         /// <inheritdoc/>
         public virtual bool IsParametrizedCommand { get; internal set; }

--- a/KUtilitiesCore.MVVM/ISupportCommands.cs
+++ b/KUtilitiesCore.MVVM/ISupportCommands.cs
@@ -25,5 +25,11 @@ namespace KUtilitiesCore.MVVM
         /// Itera sobre los comandos registrados y notifica que su estado de ejecución puede haber cambiado.
         /// </summary>
         void UpdateRegisteredCommands();
+        /// <summary>
+        /// Obtiene el Comando registrado basado en el nombre
+        /// </summary>
+        /// <param name="commandName"></param>
+        RelayCommandBase? GetRegisteredCommand(string commandName);
+        bool RemoveRegisteredCommand(string commandName);
     }
 }

--- a/KUtilitiesCore.MVVM/ViewModelHelperBase.cs
+++ b/KUtilitiesCore.MVVM/ViewModelHelperBase.cs
@@ -15,7 +15,7 @@ namespace KUtilitiesCore.MVVM
         : IViewModelHelper, ISupportParameter, ISupportCommands, ISupportParentViewModel,
         IViewModelDocumentContent, IViewModelDataErrorInfo, INotifyPropertyChanged
     {
-        private readonly List<RelayCommandBase> _registeredCommands = [];
+        private readonly Dictionary<string, RelayCommandBase> _registeredCommands = [];
         private IViewModelDocumentOwner? documentOwner;
         private string error = string.Empty;
         private ConcurrentDictionary<string, string> errorMessages = [];
@@ -140,7 +140,7 @@ namespace KUtilitiesCore.MVVM
         /// <param name="command">El comando a registrar.</param>
         void ISupportCommands.RegisterCommand<TCommand>(TCommand command)
         {
-            _registeredCommands.Add(command);
+            _registeredCommands[command.CommandName] = command;
         }
 
         /// <inheritdoc/>
@@ -172,7 +172,7 @@ namespace KUtilitiesCore.MVVM
         /// </summary>
         void ISupportCommands.UpdateRegisteredCommands()
         {
-            foreach (var command in _registeredCommands)
+            foreach (var command in _registeredCommands.Values)
             {
                 command.RaiseCanExecuteChanged();
             }
@@ -299,5 +299,16 @@ namespace KUtilitiesCore.MVVM
         {
             PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
         }
+
+        /// <inheritdoc/>
+        RelayCommandBase? ISupportCommands.GetRegisteredCommand(string commandName)
+        {
+            _registeredCommands.TryGetValue(commandName, out var registeredCommand);
+            return registeredCommand;
+        }
+
+        /// <inheritdoc/>
+        bool ISupportCommands.RemoveRegisteredCommand(string commandName)
+        => _registeredCommands.Remove(commandName);
     }
 }


### PR DESCRIPTION
…mejorada

Se introduce el campo `commandName` en `RelayCommand` y `RelayCommandBase` para facilitar la identificación única de comandos.

Se actualiza `EventCommandBinderCollection` para permitir el enlace de comandos que posean un nombre.

Se modifica `_registeredCommands` en `ViewModelHelperBase` de una lista a un diccionario, optimizando así la eficiencia en la búsqueda de comandos.

Se añaden los métodos `GetRegisteredCommand` y `RemoveRegisteredCommand` a la interfaz `ISupportCommands` y a su implementación, mejorando la gestión de comandos registrados.