### PR TITLE
fix: Mejorar descubrimiento método CanExecute

### DIFF
--- a/KUtilitiesCore.MVVM/Command/RelayCommand.cs
+++ b/KUtilitiesCore.MVVM/Command/RelayCommand.cs
@@ -324,7 +324,9 @@ namespace KUtilitiesCore.MVVM.Command
         {
             // Estrategia 1: Buscar por atributo [CanExecuteAttribute]
             var attribute = executeMethod.GetCustomAttribute<CanExecuteAttribute>();
-            string canExecuteName = attribute?.MethodName ?? $"Can{executeMethod.Name}";
+            string canExecuteName = attribute?.MethodName ?? string.Empty;
+            if(string.IsNullOrEmpty(canExecuteName))
+                canExecuteName = $"Can{executeMethod.Name}";
 
             // Estrategia 2: Buscar por convención "Can" + Nombre del método
             var bindingFlags = BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic;


### PR DESCRIPTION
Mejora el descubrimiento del método CanExecute en RelayCommand. Ahora, si el atributo `CanExecuteAttribute` especifica un nombre de método vacío, se recurre a la convención de nombrar el método como "Can" seguido del nombre del método de ejecución. Esto proporciona mayor flexibilidad en la definición de los comandos.