### PR TITLE
fix: Prevenir inicio de edición anidada

### DIFF
--- a/KUtilitiesCore/Tracking/ChangeTrackingBase.cs
+++ b/KUtilitiesCore/Tracking/ChangeTrackingBase.cs
@@ -50,6 +50,7 @@ namespace KUtilitiesCore.Tracking
         /// </summary>
         public void BeginEdit()
         {
+            if (_snapshotStack.Count > 0) return;
             var snapshot = CreateCleanSnapshot();
             _snapshotStack.Push(snapshot);
         }


### PR DESCRIPTION
Evita que `BeginEdit` se llame si ya existe una instantánea en la pila, impidiendo inicios de edición anidados y asegurando el correcto funcionamiento del rastreo de cambios.